### PR TITLE
Remove H2Pack dependency 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+include/*
+lib/*
+.vscode/*

--- a/src/H2ERI.h
+++ b/src/H2ERI.h
@@ -1,9 +1,6 @@
 #ifndef __H2ERI_H__
 #define __H2ERI_H__
 
-// H2Pack data structure and operations
-#include "H2Pack.h"
-
 // CMS interface to SIMINT
 #include "CMS.h"
 

--- a/src/H2ERI_ID_compress.h
+++ b/src/H2ERI_ID_compress.h
@@ -1,0 +1,40 @@
+#ifndef __H2ERI_ID_COMPRESS_H__
+#define __H2ERI_ID_COMPRESS_H__
+
+#include "H2ERI_config.h"
+#include "H2ERI_aux_structs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Interpolative Decomposition (ID) using partial QR over rows of a target 
+// matrix. Partial pivoting QR may need to be upgraded to SRRQR later. 
+// Given an m*n matrix A, an rank-k ID approximation of A is of form
+//         A = U * A(J, :)
+// where J is a row index subset of size k, and U is a m*k matrix (if 
+// SRRQR is used, entries of U are bounded by a parameter 'f'). A(J,:) 
+// and U are usually called the skeleton and projection matrix. 
+// Input parameters:
+//   A          : Target matrix, stored in row major
+//   stop_type  : Partial QR stop criteria: QR_RANK, QR_REL_NRM, or QR_ABS_NRM
+//   stop_param : Pointer to partial QR stop parameter
+//   n_thread   : Number of threads used in this function
+//   QR_buff    : Working buffer for partial pivoting QR. If kdim == 1, size A->nrow.
+//                If kdim > 1, size (2*kdim+2)*A->ncol + (kdim+1)*A->nrow.
+//   ID_buff    : Size 4 * A->nrow, working buffer for ID compression
+//   kdim       : Dimension of tensor kernel's return (column block size)
+// Output parameters:
+//   U_ : Projection matrix, will be initialized in this function. If U_ == NULL,
+//        the projection matrix will not be calculated.
+//   J  : Row indices of the skeleton A
+void H2E_ID_compress(
+    H2E_dense_mat_p A, const int stop_type, void *stop_param, H2E_dense_mat_p *U_, 
+    H2E_int_vec_p J, const int n_thread, DTYPE *QR_buff, int *ID_buff, const int kdim
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/H2ERI_aux_structs.c
+++ b/src/H2ERI_aux_structs.c
@@ -1,0 +1,452 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <math.h>
+
+#include "H2ERI_aux_structs.h"
+#include "utils.h"
+
+// ========================== H2E_tree_node ========================== //
+
+// Initialize an H2E_tree_node structure
+void H2E_tree_node_init(H2E_tree_node_p *node_, const int dim)
+{
+    const int max_child = 1 << dim;
+    H2E_tree_node_p node = (H2E_tree_node_p) malloc(sizeof(struct H2E_tree_node));
+    ASSERT_PRINTF(node != NULL, "Failed to allocate H2E_tree_node structure\n");
+    node->children = (void**) malloc(sizeof(H2E_tree_node_p) * max_child);
+    node->enbox    = (DTYPE*) malloc(sizeof(DTYPE) * dim * 2);
+    ASSERT_PRINTF(
+        node->children != NULL && node->enbox != NULL,
+        "Failed to allocate arrays in an H2E_tree_node structure\n"
+    );
+    for (int i = 0; i < max_child; i++) 
+        node->children[i] = NULL;
+    *node_ = node;
+}
+
+// Recursively destroy an H2E_tree_node node and its children nodes
+void H2E_tree_node_destroy(H2E_tree_node_p *node_)
+{
+    H2E_tree_node_p node = *node_;
+    if (node == NULL) return;
+    for (int i = 0; i < node->n_child; i++)
+    {
+        H2E_tree_node_p child_i = (H2E_tree_node_p) node->children[i];
+        if (child_i != NULL) H2E_tree_node_destroy(&child_i);
+        free(child_i);
+    }
+    free(node->children);
+    free(node->enbox);
+    free(node);
+    *node_ = NULL;
+}
+
+// ------------------------------------------------------------------- // 
+
+
+// =========================== H2E_int_vec =========================== //
+
+// Initialize an H2E_int_vec structure
+void H2E_int_vec_init(H2E_int_vec_p *int_vec_, int capacity)
+{
+    if (capacity < 0) capacity = 128;
+    H2E_int_vec_p int_vec = (H2E_int_vec_p) malloc(sizeof(struct H2E_int_vec));
+    ASSERT_PRINTF(int_vec != NULL, "Failed to allocate H2E_int_vec structure\n");
+    int_vec->data = (int*) malloc(sizeof(int) * capacity);
+    ASSERT_PRINTF(int_vec->data != NULL, "Failed to allocate integer vector of size %d\n", capacity);
+    int_vec->capacity = capacity;
+    int_vec->length = 0;
+    *int_vec_ = int_vec;
+}
+
+// Destroy an H2E_int_vec structure
+void H2E_int_vec_destroy(H2E_int_vec_p *int_vec_)
+{
+    H2E_int_vec_p int_vec = *int_vec_;
+    if (int_vec == NULL) return;
+    free(int_vec->data);
+    free(int_vec);
+    *int_vec_ = NULL;
+}
+
+// Free the memory used by an H2E_int_vec structure and reset its capacity to 128
+void H2E_int_vec_reset(H2E_int_vec_p int_vec)
+{
+    if (int_vec == NULL) return;
+    free(int_vec->data);
+    int_vec->capacity = 128;
+    int_vec->length   = 0;
+    int_vec->data = (int*) malloc(sizeof(int) * int_vec->capacity);
+    ASSERT_PRINTF(int_vec->data != NULL, "Failed to allocate integer vector of size %d\n", int_vec->capacity);
+}
+
+// Concatenate values in an H2E_int_vec to another H2E_int_vec
+void H2E_int_vec_concatenate(H2E_int_vec_p dst_vec, H2E_int_vec_p src_vec)
+{
+    int s_len = src_vec->length;
+    int d_len = dst_vec->length;
+    int new_length = s_len + d_len;
+    if (new_length > dst_vec->capacity)
+        H2E_int_vec_set_capacity(dst_vec, new_length);
+    memcpy(dst_vec->data + d_len, src_vec->data, sizeof(int) * s_len);
+    dst_vec->length = new_length;
+}
+
+// Gather elements in an H2E_int_vec to another H2E_int_vec
+void H2E_int_vec_gather(H2E_int_vec_p src_vec, H2E_int_vec_p idx, H2E_int_vec_p dst_vec)
+{
+    H2E_int_vec_set_capacity(dst_vec, idx->length);
+    for (int i = 0; i < idx->length; i++)
+        dst_vec->data[i] = src_vec->data[idx->data[i]];
+    dst_vec->length = idx->length;
+}
+
+// ------------------------------------------------------------------- // 
+
+
+// ======================= H2E_partition_vars ======================== //
+
+// Initialize an H2E_partition_vars structure
+void H2E_partition_vars_init(H2E_partition_vars_p *part_vars_)
+{
+    H2E_partition_vars_p part_vars = (H2E_partition_vars_p) malloc(sizeof(struct H2E_partition_vars));
+    H2E_int_vec_init(&part_vars->r_adm_pairs,   10240);
+    H2E_int_vec_init(&part_vars->r_inadm_pairs, 10240);
+    part_vars->curr_po_idx = 0;
+    part_vars->max_level   = 0;
+    part_vars->n_leaf_node = 0;
+    *part_vars_ = part_vars;
+}
+
+// Destroy an H2E_partition_vars structure
+void H2E_partition_vars_destroy(H2E_partition_vars_p *part_vars_)
+{
+    H2E_partition_vars_p part_vars = *part_vars_;
+    if (part_vars == NULL) return;
+    H2E_int_vec_destroy(&part_vars->r_adm_pairs);
+    H2E_int_vec_destroy(&part_vars->r_inadm_pairs);
+    free(part_vars->r_adm_pairs);
+    free(part_vars->r_inadm_pairs);
+    free(part_vars);
+    *part_vars_ = NULL;
+}
+
+// ------------------------------------------------------------------- // 
+
+
+// ========================== H2E_dense_mat ========================== //
+
+// Initialize an H2E_dense_mat structure
+void H2E_dense_mat_init(H2E_dense_mat_p *mat_, const int nrow, const int ncol)
+{
+    H2E_dense_mat_p mat = (H2E_dense_mat_p) malloc(sizeof(struct H2E_dense_mat));
+    ASSERT_PRINTF(mat != NULL, "Failed to allocate H2E_dense_mat structure\n");
+    
+    mat->nrow = MAX(0, nrow);
+    mat->ncol = MAX(0, ncol);
+    mat->ld   = mat->ncol;
+    mat->size = mat->nrow * mat->ncol;
+    if (mat->size > 0)
+    {
+        mat->data = malloc_aligned(sizeof(DTYPE) * mat->size, 64);
+        ASSERT_PRINTF(mat->data != NULL, "Failed to allocate %d * %d dense matrix\n", nrow, ncol);
+    } else {
+        mat->data = NULL;
+    }
+    
+    *mat_ = mat;
+}
+
+// Destroy an H2E_dense_mat structure
+void H2E_dense_mat_destroy(H2E_dense_mat_p *mat_)
+{
+    H2E_dense_mat_p mat = *mat_;
+    if (mat == NULL) return;
+    free_aligned(mat->data);
+    free(mat);
+    *mat_ = NULL;
+}
+
+// Reset an H2E_dense_mat structure to its default size (0-by-0) and release the memory
+void H2E_dense_mat_reset(H2E_dense_mat_p mat)
+{
+    if (mat == NULL) return;
+    free_aligned(mat->data);
+    mat->data = NULL;
+    mat->size = 0;
+    mat->nrow = 0;
+    mat->ncol = 0;
+    mat->ld   = 0;
+}
+
+// Copy the data in an H2E_dense_mat structure to another H2E_dense_mat structure
+void H2E_dense_mat_copy(H2E_dense_mat_p src_mat, H2E_dense_mat_p dst_mat)
+{
+    H2E_dense_mat_resize(dst_mat, src_mat->nrow, src_mat->ncol);
+    copy_matrix_block(sizeof(DTYPE), src_mat->nrow, src_mat->ncol, src_mat->data, src_mat->ld, dst_mat->data, dst_mat->ld);
+}
+
+// Permute rows in an H2E_dense_mat structure
+void H2E_dense_mat_permute_rows(H2E_dense_mat_p mat, const int *p)
+{
+    DTYPE *mat_dst = (DTYPE*) malloc_aligned(sizeof(DTYPE) * mat->nrow * mat->ncol, 64);
+    ASSERT_PRINTF(mat_dst != NULL, "Failed to allocate buffer of size %d * %d\n", mat->nrow, mat->ncol);
+    
+    for (int irow = 0; irow < mat->nrow; irow++)
+    {
+        DTYPE *src_row = mat->data + p[irow] * mat->ld;
+        DTYPE *dst_row = mat_dst + irow * mat->ncol;
+        memcpy(dst_row, src_row, sizeof(DTYPE) * mat->ncol);
+    }
+    
+    free_aligned(mat->data);
+    mat->ld   = mat->ncol;
+    mat->size = mat->nrow * mat->ncol;
+    mat->data = mat_dst;
+}
+
+// Select rows in an H2E_dense_mat structure
+void H2E_dense_mat_select_rows(H2E_dense_mat_p mat, H2E_int_vec_p row_idx)
+{
+    for (int irow = 0; irow < row_idx->length; irow++)
+    {
+        DTYPE *src = mat->data + row_idx->data[irow] * mat->ld;
+        DTYPE *dst = mat->data + irow * mat->ld;
+        if (src != dst) memcpy(dst, src, sizeof(DTYPE) * mat->ncol);
+    }
+    mat->nrow = row_idx->length;
+}
+
+// Select columns in an H2E_dense_mat structure
+void H2E_dense_mat_select_columns(H2E_dense_mat_p mat, H2E_int_vec_p col_idx)
+{
+    for (int irow = 0; irow < mat->nrow; irow++)
+    {
+        DTYPE *mat_row = mat->data + irow * mat->ld;
+        for (int icol = 0; icol < col_idx->length; icol++)
+            mat_row[icol] = mat_row[col_idx->data[icol]];
+    }
+    mat->ncol = col_idx->length;
+    for (int irow = 1; irow < mat->nrow; irow++)
+    {
+        DTYPE *src = mat->data + irow * mat->ld;
+        DTYPE *dst = mat->data + irow * mat->ncol;
+        memmove(dst, src, sizeof(DTYPE) * mat->ncol);
+    }
+    mat->ld = mat->ncol;
+}
+
+// Normalize columns in an H2E_dense_mat structure
+void H2E_dense_mat_normalize_columns(H2E_dense_mat_p mat, H2E_dense_mat_p workbuf)
+{
+    int nrow = mat->nrow, ncol = mat->ncol;
+    H2E_dense_mat_resize(workbuf, 1, ncol);
+    DTYPE *inv_2norm = workbuf->data;
+    
+    #if 0
+    #pragma omp simd
+    for (int icol = 0; icol < ncol; icol++) 
+        inv_2norm[icol] = mat->data[icol] * mat->data[icol];
+    for (int irow = 1; irow < nrow; irow++)
+    {
+        DTYPE *mat_row = mat->data + irow * mat->ld;
+        #pragma omp simd
+        for (int icol = 0; icol < ncol; icol++) 
+            inv_2norm[icol] += mat_row[icol] * mat_row[icol];
+    }
+    #pragma omp simd
+    for (int icol = 0; icol < ncol; icol++) 
+        inv_2norm[icol] = 1.0 / DSQRT(inv_2norm[icol]);
+    #endif
+
+    // Slower, but more accurate
+    for (int icol = 0; icol < ncol; icol++)
+        inv_2norm[icol] = 1.0 / CBLAS_NRM2(nrow, mat->data + icol, ncol);
+    
+    for (int irow = 0; irow < nrow; irow++)
+    {
+        DTYPE *mat_row = mat->data + irow * mat->ld;
+        #pragma omp simd
+        for (int icol = 0; icol < ncol; icol++) 
+            mat_row[icol] *= inv_2norm[icol];
+    }
+}
+
+// Perform GEMM C := alpha * op(A) * op(B) + beta * C
+void H2E_dense_mat_gemm(
+    const DTYPE alpha, const DTYPE beta, const int transA, const int transB, 
+    H2E_dense_mat_p A, H2E_dense_mat_p B, H2E_dense_mat_p C
+)
+{
+    int M, N, KA, KB;
+    CBLAS_TRANSPOSE transA_, transB_;
+    if (transA == 0)
+    {
+        transA_ = CblasNoTrans;
+        M  = A->nrow;
+        KA = A->ncol;
+    } else {
+        transA_ = CblasTrans;
+        M  = A->ncol;
+        KA = A->nrow;
+    }
+    if (transB == 0)
+    {
+        transB_ = CblasNoTrans;
+        N  = B->ncol;
+        KB = B->nrow;
+    } else {
+        transB_ = CblasTrans;
+        N  = B->nrow;
+        KB = B->ncol;
+    }
+    if (KA != KB)
+    {
+        ERROR_PRINTF("GEMM size mismatched: A[%d * %d], B[%d * %d]\n", M, KA, KB, N);
+        return;
+    }
+    if (beta == 0.0 && (C->nrow < M || C->ncol < N)) H2E_dense_mat_resize(C, M, N);
+    CBLAS_GEMM(
+        CblasRowMajor, transA_, transB_, M, N, KA,
+        alpha, A->data, A->ld, B->data, B->ld, 
+        beta,  C->data, C->ld
+    );
+}
+
+// Create a block diagonal matrix created by aligning the input matrices along the diagonal
+void H2E_dense_mat_blkdiag(H2E_dense_mat_p *mats, H2E_int_vec_p idx, H2E_dense_mat_p new_mat)
+{
+    int nrow = 0, ncol = 0;
+    for (int i = 0; i < idx->length; i++)
+    {
+        H2E_dense_mat_p mat_i = mats[idx->data[i]];
+        nrow += mat_i->nrow;
+        ncol += mat_i->ncol;
+    }
+    H2E_dense_mat_resize(new_mat, nrow, ncol);
+    memset(new_mat->data, 0, sizeof(DTYPE) * nrow * ncol);
+    nrow = 0; ncol = 0;
+    for (int i = 0; i < idx->length; i++)
+    {
+        H2E_dense_mat_p mat_i = mats[idx->data[i]];
+        int nrow_i = mat_i->nrow;
+        int ncol_i = mat_i->ncol;
+        DTYPE *dst = new_mat->data + nrow * new_mat->ld + ncol;
+        copy_matrix_block(sizeof(DTYPE), nrow_i, ncol_i, mat_i->data, mat_i->ld, dst, new_mat->ld);
+        nrow += nrow_i;
+        ncol += ncol_i;
+    }
+}
+
+// Vertically concatenates the input matrices
+void H2E_dense_mat_vertcat(H2E_dense_mat_p *mats, H2E_int_vec_p idx, H2E_dense_mat_p new_mat)
+{
+    int nrow = 0, ncol = mats[idx->data[0]]->ncol;
+    for (int i = 0; i < idx->length; i++)
+    {
+        H2E_dense_mat_p mat_i = mats[idx->data[i]];
+        if (mat_i->ncol != ncol)
+        {
+            ERROR_PRINTF("%d-th matrix has %d columns, 1st matrix has %d columns\n", i+1, mat_i->ncol, ncol);
+            return;
+        }
+        nrow += mat_i->nrow;
+    }
+    H2E_dense_mat_resize(new_mat, nrow, ncol);
+    nrow = 0; ncol = 0;
+    for (int i = 0; i < idx->length; i++)
+    {
+        H2E_dense_mat_p mat_i = mats[idx->data[i]];
+        int nrow_i = mat_i->nrow;
+        int ncol_i = mat_i->ncol;
+        DTYPE *dst = new_mat->data + nrow * new_mat->ld;
+        copy_matrix_block(sizeof(DTYPE), nrow_i, ncol_i, mat_i->data, mat_i->ld, dst, new_mat->ld);
+        nrow += nrow_i;
+    }
+}
+
+// Horizontally concatenates the input matrices
+void H2E_dense_mat_horzcat(H2E_dense_mat_p *mats, H2E_int_vec_p idx, H2E_dense_mat_p new_mat)
+{
+    int nrow = mats[idx->data[0]]->nrow, ncol = 0;
+    for (int i = 0; i < idx->length; i++)
+    {
+        H2E_dense_mat_p mat_i = mats[idx->data[i]];
+        if (mat_i->nrow != nrow)
+        {
+            ERROR_PRINTF("%d-th matrix has %d rows, 1st matrix has %d rows\n", i+1, mat_i->nrow, nrow);
+            return;
+        }
+        ncol += mat_i->ncol;
+    }
+    H2E_dense_mat_resize(new_mat, nrow, ncol);
+    memset(new_mat->data, 0, sizeof(DTYPE) * nrow * ncol);
+    nrow = 0; ncol = 0;
+    for (int i = 0; i < idx->length; i++)
+    {
+        H2E_dense_mat_p mat_i = mats[idx->data[i]];
+        int nrow_i = mat_i->nrow;
+        int ncol_i = mat_i->ncol;
+        DTYPE *dst = new_mat->data + ncol;
+        copy_matrix_block(sizeof(DTYPE), nrow_i, ncol_i, mat_i->data, mat_i->ld, dst, new_mat->ld);
+        ncol += mat_i->ncol;
+    }
+}
+
+// Print an H2E_dense_mat structure, for debugging
+void H2E_dense_mat_print(H2E_dense_mat_p mat)
+{
+    for (int irow = 0; irow < mat->nrow; irow++)
+    {
+        DTYPE *mat_row = mat->data + irow * mat->ld;
+        for (int icol = 0; icol < mat->ncol; icol++) printf("% .4lf  ", mat_row[icol]);
+        printf("\n");
+    }
+}
+
+// ------------------------------------------------------------------- // 
+
+
+// ========================== H2E_thread_buf ========================= //
+
+void H2E_thread_buf_init(H2E_thread_buf_p *thread_buf_, const int krnl_mat_size)
+{
+    H2E_thread_buf_p thread_buf = (H2E_thread_buf_p) malloc(sizeof(struct H2E_thread_buf));
+    ASSERT_PRINTF(thread_buf != NULL, "Failed to allocate H2E_thread_buf structure\n");
+    H2E_int_vec_init(&thread_buf->idx0, 1024);
+    H2E_int_vec_init(&thread_buf->idx1, 1024);
+    H2E_dense_mat_init(&thread_buf->mat0, 1024, 1);
+    H2E_dense_mat_init(&thread_buf->mat1, 1024, 1);
+    H2E_dense_mat_init(&thread_buf->mat2, 1024, 1);
+    thread_buf->y = (DTYPE*) malloc_aligned(sizeof(DTYPE) * krnl_mat_size, 64);
+    ASSERT_PRINTF(thread_buf->y != NULL, "Failed to allocate y of size %d in H2E_thread_buf\n", krnl_mat_size);
+    *thread_buf_ = thread_buf;
+}
+
+void H2E_thread_buf_destroy(H2E_thread_buf_p *thread_buf_)
+{
+    H2E_thread_buf_p thread_buf = *thread_buf_;
+    if (thread_buf == NULL) return;
+    H2E_int_vec_destroy(&thread_buf->idx0);
+    H2E_int_vec_destroy(&thread_buf->idx1);
+    H2E_dense_mat_destroy(&thread_buf->mat0);
+    H2E_dense_mat_destroy(&thread_buf->mat1);
+    H2E_dense_mat_destroy(&thread_buf->mat2);
+    free_aligned(thread_buf->y);
+    free(thread_buf);
+    *thread_buf_ = NULL;
+}
+
+void H2E_thread_buf_reset(H2E_thread_buf_p thread_buf)
+{
+    if (thread_buf == NULL) return;
+    H2E_int_vec_reset(thread_buf->idx0);
+    H2E_int_vec_reset(thread_buf->idx1);
+    H2E_dense_mat_reset(thread_buf->mat0);
+    H2E_dense_mat_reset(thread_buf->mat1);
+    H2E_dense_mat_reset(thread_buf->mat2);
+}
+
+// ------------------------------------------------------------------- // 

--- a/src/H2ERI_aux_structs.h
+++ b/src/H2ERI_aux_structs.h
@@ -1,0 +1,319 @@
+#ifndef __H2ERI_AUX_STRUCTS_H__
+#define __H2ERI_AUX_STRUCTS_H__
+
+#include "H2ERI_config.h"
+#include "utils.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ========================== H2 tree linked list node ========================== //
+struct H2E_tree_node
+{
+    int   n_child;        // Number of children nodes 
+    int   n_node;         // Number of nodes this sub-tree has
+    int   po_idx;         // Post-order traversal index of this node
+    int   level;          // Level of this node on the tree (root == 0)
+    int   height;         // Height of this node on the tree (leaf node == 0)
+    int   pt_cluster[2];  // The start and end indices of points belong to this node
+    void  **children;     // Size 2^dim, all children nodes of this node
+    DTYPE *enbox;         // Size 2*dim, box that encloses all points of this node. 
+                          // enbox[0 : dim-1] are the smallest corner coordinate,
+                          // enbox[dim : 2*dim-1] are the size of this box.
+};
+typedef struct H2E_tree_node* H2E_tree_node_p;
+
+// Initialize an H2E_tree_node structure
+// Input parameter:
+//   dim : Dimension of point coordinate
+// Output parameter:
+//   node_ : Initialized H2E_tree_node structure
+void H2E_tree_node_init(H2E_tree_node_p *node_, const int dim);
+
+// Recursively destroy an H2E_tree_node node and its children nodes
+// Input parameter:
+//   node : H2E_tree_node structure to be destroyed
+void H2E_tree_node_destroy(H2E_tree_node_p *node_);
+
+// ------------------------------------------------------------------------------ // 
+
+
+// =============== Integer vector, similar to std::vector in C++ ================ //
+
+struct H2E_int_vec
+{
+    int capacity;    // Capacity of this vector
+    int length;      // Current length of this vector
+    int *data;       // Data in this vector
+};
+typedef struct H2E_int_vec* H2E_int_vec_p;
+
+// Initialize an H2E_int_vec structure
+// Input parameter:
+//   capacity : Initial capacity of the vector. If (capacity <= 0 || capacity >= 65536),
+//              capacity will be set as 128.
+// Output parameter:
+//   int_vec_ : Initialized H2E_int_vec structure
+void H2E_int_vec_init(H2E_int_vec_p *int_vec_, int capacity);
+
+// Destroy an H2E_int_vec structure
+// Input parameter:
+//   int_vec : H2E_int_vec structure to be destroyed
+void H2E_int_vec_destroy(H2E_int_vec_p *int_vec_);
+
+// Reset an H2E_int_vec structure to its default capacity and release the memory
+// Input parameter:
+//   int_vec : H2E_int_vec structure to be reset
+void H2E_int_vec_reset(H2E_int_vec_p int_vec);
+
+// Set the capacity of an initialized H2E_int_vec structure. If new 
+// capacity > original capacity, allocate a new data buffer and copy 
+// values to the new buffer. Otherwise, do nothing.
+// Frequently used, inline it.
+// Input parameters:
+//   int_vec  : Initialized H2E_int_vec structure
+//   capacity : New capacity
+// Output parameter:
+//   int_vec  : H2E_int_vec structure with adjusted capacity
+static inline void H2E_int_vec_set_capacity(H2E_int_vec_p int_vec, const int capacity)
+{
+    if (capacity > int_vec->capacity)
+    {
+        int *new_data = (int*) malloc(sizeof(int) * capacity);
+        ASSERT_PRINTF(new_data != NULL, "Failed to reallocate integer vector of size %d", capacity);
+        int_vec->capacity = capacity;
+        memcpy(new_data, int_vec->data, sizeof(int) * int_vec->length);
+        free(int_vec->data);
+        int_vec->data = new_data;
+    }
+}
+
+// Push an integer to the tail of an H2E_int_vec, inline it for frequently use
+// Input parameters:
+//   int_vec : H2E_int_vec structure
+//   value   : Value to be pushed 
+// Output parameter:
+//   int_vec : H2E_int_vec structure with the pushed value
+static inline void H2E_int_vec_push_back(H2E_int_vec_p int_vec, int value)
+{
+    if (int_vec->capacity == int_vec->length)
+        H2E_int_vec_set_capacity(int_vec, int_vec->capacity * 2);
+    int_vec->data[int_vec->length] = value;
+    int_vec->length++;
+}
+
+// Concatenate values in an H2E_int_vec to another H2E_int_vec
+// Input parameters:
+//   dst_vec : Destination H2E_int_vec structure
+//   src_vec : Source H2E_int_vec structure
+// Output parameter:
+//   dst_vec : Destination H2E_int_vec structure
+void H2E_int_vec_concatenate(H2E_int_vec_p dst_vec, H2E_int_vec_p src_vec);
+
+// Gather elements in an H2E_int_vec to another H2E_int_vec
+// Input parameters:
+//   src_vec : Source H2E_int_vec structure
+//   idx     : Indices of elements to be gathered
+// Output parameter:
+//   dst_vec : Destination H2E_int_vec structure
+void H2E_int_vec_gather(H2E_int_vec_p src_vec, H2E_int_vec_p idx, H2E_int_vec_p dst_vec);
+
+// ------------------------------------------------------------------------------ // 
+
+
+// ========== Working variables and arrays used in point partitioning =========== //
+
+struct H2E_partition_vars
+{
+    int curr_po_idx;                // Post-order traversal index
+    int max_level;                  // Maximum level of the H2 tree
+    int n_leaf_node;                // Number of leaf nodes
+    int curr_leaf_idx;              // Index of this leaf node
+    int min_adm_level;              // Minimum level of reduced admissible pair
+    H2E_int_vec_p r_inadm_pairs;    // Reduced inadmissible pairs
+    H2E_int_vec_p r_adm_pairs;      // Reduced admissible pairs
+};
+typedef struct H2E_partition_vars* H2E_partition_vars_p;
+
+// Initialize an H2E_partition_vars structure
+void H2E_partition_vars_init(H2E_partition_vars_p *vars_);
+
+// Destroy an H2E_partition_vars structure
+void H2E_partition_vars_destroy(H2E_partition_vars_p *vars_);
+
+// ------------------------------------------------------------------------------ // 
+
+
+// ========== Simple dense matrix structure with some basic operations ========== //
+
+struct H2E_dense_mat
+{
+    int   nrow;   // Number of rows
+    int   ncol;   // Number of columns
+    int   ld;     // Leading dimension, >= ncol
+    int   size;   // Size of data, >= nrow * ncol
+    DTYPE *data;  // Matrix data
+};
+typedef struct H2E_dense_mat* H2E_dense_mat_p;
+
+// Initialize an H2E_dense_mat structure
+// Input parameters:
+//   nrow : Number of rows of the new dense matrix
+//   ncol : Number of columns of the new dense matrix
+// Output parameter:
+//   mat_ : Initialized H2E_dense_mat structure
+void H2E_dense_mat_init(H2E_dense_mat_p *mat_, const int nrow, const int ncol);
+
+// Destroy an H2E_dense_mat structure
+// Input parameter:
+//   mat : H2E_dense_mat structure to be destroyed 
+void H2E_dense_mat_destroy(H2E_dense_mat_p *mat_);
+
+// Reset an H2E_dense_mat structure to its default size (0-by-0) and release the memory
+// Input parameter:
+//   mat : H2E_dense_mat structure to be reset 
+void H2E_dense_mat_reset(H2E_dense_mat_p mat);
+
+// Resize an initialized H2E_dense_mat structure, original data in 
+// the dense matrix will be unavailable after this operation.
+// Frequently used, inline it.
+// Input parameters:
+//   nrow : Number of rows of the new dense matrix
+//   ncol : Number of columns of the new dense matrix
+// Output parameter:
+//   mat  : Resized H2E_dense_mat structure
+static inline void H2E_dense_mat_resize(H2E_dense_mat_p mat, const int nrow, const int ncol)
+{
+    int new_size = nrow * ncol;
+    mat->nrow = nrow;
+    mat->ncol = ncol;
+    mat->ld   = ncol;
+    if (new_size > mat->size)
+    {
+        free_aligned(mat->data);
+        mat->data = (DTYPE*) malloc_aligned(sizeof(DTYPE) * new_size, 64);
+        ASSERT_PRINTF(mat->data != NULL, "Failed to reallocate %d * %d dense matrix\n", nrow, ncol);
+        mat->size = new_size;
+    }
+}
+
+// Copy the data in an H2E_dense_mat structure to another H2E_dense_mat structure
+// Input parameter:
+//   src_mat : Source H2E_dense_mat
+// Output parameter:
+//   dst_mat : Destination H2E_dense_mat
+void H2E_dense_mat_copy(H2E_dense_mat_p src_mat, H2E_dense_mat_p dst_mat);
+
+// Permute rows in an H2E_dense_mat structure
+// WARNING: This function DOES NOT perform sanity check!
+// Input parameters:
+//   mat : H2E_dense_mat structure to be permuted
+//   p   : Permutation array. After permutation, the i-th row is the p[i]-th row
+//         in the original matrix
+// Output parameter:
+//   mat : H2E_dense_mat structure with permuted row
+void H2E_dense_mat_permute_rows(H2E_dense_mat_p mat, const int *p);
+
+// Select rows in an H2E_dense_mat structure
+// WARNING: This function DOES NOT perform sanity check!
+// Input parameters:
+//   mat     : H2E_dense_mat structure to be selected
+//   row_idx : Row index array, sorted in ascending order. The i-th row in the
+//             new matrix is the row_idx->data[i]-th row in the original matrix
+// Output parameter:
+//   mat : H2E_dense_mat structure with selected rows
+void H2E_dense_mat_select_rows(H2E_dense_mat_p mat, H2E_int_vec_p row_idx);
+
+// Select columns in an H2E_dense_mat structure
+// WARNING: This function DOES NOT perform sanity check!
+// Input parameters:
+//   mat     : H2E_dense_mat structure to be selected
+//   col_idx : Column index array, sorted in ascending order. The i-th column in the
+//             new matrix is the col_idx->data[i]-th column in the original matrix
+// Output parameter:
+//   mat : H2E_dense_mat structure with selected columns
+void H2E_dense_mat_select_columns(H2E_dense_mat_p mat, H2E_int_vec_p col_idx);
+
+// Normalize columns in an H2E_dense_mat structure
+// Input parameters:
+//   mat     : H2E_dense_mat structure to be normalized columns
+//   workbuf : H2E_dense_mat structure as working buffer
+// Output parameter:
+//   mat     : H2E_dense_mat structure with normalized columns
+void H2E_dense_mat_normalize_columns(H2E_dense_mat_p mat, H2E_dense_mat_p workbuf);
+
+// Perform GEMM C := alpha * op(A) * op(B) + beta * C
+// Input parameters:
+//   alpha, beta    : Scaling factors
+//   transA, transB : If A / B need to be transposed
+//   A, B           : Source matrices
+// Output parameter:
+//   C : Result matrix, need to be properly resized before entering if beta != 0
+void H2E_dense_mat_gemm(
+    const DTYPE alpha, const DTYPE beta, const int transA, const int transB, 
+    H2E_dense_mat_p A, H2E_dense_mat_p B, H2E_dense_mat_p C
+);
+
+// Create a block diagonal matrix created by aligning the input matrices along the diagonal
+// Input parameters:
+//   mats : Size unknown, candidate H2E_dense_mat_t matrices
+//   idx  : Size unknown, indices of the input matrices in the candidate set
+// Output parameter:
+//   new_mat : The result matrix
+void H2E_dense_mat_blkdiag(H2E_dense_mat_p *mats, H2E_int_vec_p idx, H2E_dense_mat_p new_mat);
+
+// Vertically concatenates the input matrices
+// Input / output parameters are the same as H2E_dense_mat_blkdiag()
+void H2E_dense_mat_vertcat(H2E_dense_mat_p *mats, H2E_int_vec_p idx, H2E_dense_mat_p new_mat);
+
+// Horizontally concatenates the input matrices
+// Input / output parameters are the same as H2E_dense_mat_blkdiag()
+void H2E_dense_mat_horzcat(H2E_dense_mat_p *mats, H2E_int_vec_p idx, H2E_dense_mat_p new_mat);
+
+// Print an H2E_dense_mat structure, for debugging
+// Input parameter:
+//   mat : H2E_dense_mat structure to be printed
+void H2E_dense_mat_print(H2E_dense_mat_p mat);
+
+// ------------------------------------------------------------------------------ // 
+
+
+// ================ Thread-local buffer used in build and matvec ================ //
+
+struct H2E_thread_buf
+{
+    H2E_int_vec_p   idx0;   // H2E_build_H2_UJ_proxy, H2E_build_HSS_UJ_hybrid
+    H2E_int_vec_p   idx1;   // H2E_build_H2_UJ_proxy, H2E_build_HSS_UJ_hybrid
+    H2E_dense_mat_p mat0;   // H2E_build_H2_UJ_proxy, H2E_build_HSS_UJ_hybrid
+    H2E_dense_mat_p mat1;   // H2E_build_H2_UJ_proxy, H2E_build_HSS_UJ_hybrid, H2E_matvec
+    H2E_dense_mat_p mat2;   // H2E_build_HSS_UJ_hybrid
+    DTYPE  *y;              // Used in H2E_matvec
+    double timer;           // Used for profiling
+};
+typedef struct H2E_thread_buf* H2E_thread_buf_p;
+
+// Initialize an H2E_thread_buf structure
+// Input parameter:
+//   krnl_mat_size : Size of the kernel matrix
+// Output parameter:
+//   thread_buf_ : Initialized H2E_thread_buf structure
+void H2E_thread_buf_init(H2E_thread_buf_p *thread_buf_, const int krnl_mat_size);
+
+// Destroy an H2E_thread_buf structure
+// Input parameter:
+//   thread_buf : H2E_thread_buf structure to be destroyed 
+void H2E_thread_buf_destroy(H2E_thread_buf_p *thread_buf_);
+
+// Reset an H2E_thread_buf structure (release memory)
+// Input parameter:
+//   thread_buf : H2E_thread_buf structure to be reset 
+void H2E_thread_buf_reset(H2E_thread_buf_p thread_buf);
+
+// ------------------------------------------------------------------------------ // 
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/H2ERI_build_Coulomb.c
+++ b/src/H2ERI_build_Coulomb.c
@@ -5,12 +5,9 @@
 
 #include <omp.h>
 
-#include "H2Pack_matvec.h"
-#include "H2Pack_utils.h"
 #include "H2ERI_typedef.h"
 #include "H2ERI_build_Coulomb.h"
 #include "H2ERI_matvec.h"
-#include "utils.h"  // In H2Pack
 
 // "Uncontract" the density matrix according to SSP and unroll 
 // the result to a column for H2 matvec.

--- a/src/H2ERI_build_H2.h
+++ b/src/H2ERI_build_H2.h
@@ -2,7 +2,6 @@
 #define __H2ERI_BUILD_H2_H__
 
 #include "H2ERI_typedef.h"
-#include "H2Pack_aux_structs.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/H2ERI_config.h
+++ b/src/H2ERI_config.h
@@ -1,0 +1,102 @@
+#ifndef __H2ERI_CONFIG_H__
+#define __H2ERI_CONFIG_H__
+
+// Parameters used in H2P-ERI
+
+#define DOUBLE_SIZE     8
+#define FLOAT_SIZE      4
+
+#ifndef DTYPE_SIZE
+#define DTYPE_SIZE      DOUBLE_SIZE     // Matrix data type: double or float
+#endif
+
+#if DTYPE_SIZE == DOUBLE_SIZE           // Marcos for double data type
+#define DTYPE           double          // Data type
+#define DTYPE_FMTSTR    "%lf"           // Data type format string
+#define DABS            fabs            // Abs function
+#define DLOG            log             // Natural logarithm function
+#define DLOG2           log2            // Base-2 logarithm function
+#define DEXP            exp             // Exponential function
+#define DPOW            pow             // Power function
+#define DSQRT           sqrt            // Sqrt function
+#define DSIN            sin             // Sine function
+#define DCOS            cos             // Cosine function
+#define DERF            erf             // Erf function
+#define DERFC           erfc            // Erfc function
+#define DFLOOR          floor           // Floor function
+#define DROUND          round           // Rounding function
+#define DCEIL           ceil            // Ceiling function
+#define DFMOD           fmod            // Floating point remainder function
+#define CBLAS_NRM2      cblas_dnrm2     // CBLAS vector 2-norm 
+#define CBLAS_DOT       cblas_ddot      // CBLAS vector dot product
+#define CBLAS_GEMV      cblas_dgemv     // CBLAS matrix-vector multiplication
+#define CBLAS_GEMM      cblas_dgemm     // CBLAS matrix-matrix multiplication
+#define CBLAS_GER       cblas_dger      // CBLAS matrix rank-1 update
+#define CBLAS_TRSM      cblas_dtrsm     // CBLAS triangle solve
+#define LAPACK_GETRF    LAPACKE_dgetrf  // LAPACK LU factorization
+#define LAPACK_GETRS    LAPACKE_dgetrs  // LAPACK linear system solve using LU factorization
+#define LAPACK_GETRI    LAPACKE_dgetri  // LAPACK LU inverse matrix
+#define LAPACK_POTRF    LAPACKE_dpotrf  // LAPACK Cholesky factorization
+#define LAPACK_POTRS    LAPACKE_dpotrs  // LAPACK linear system solve using Cholesky factorization
+#define LAPACK_GEQRF    LAPACKE_dgeqrf  // LAPACK QR factorization
+#define LAPACK_GEQPF    LAPACKE_dgeqpf  // LAPACK QR factorization with column pivoting
+#define LAPACK_ORGQR    LAPACKE_dorgqr  // LAPACK QR Q matrix explicitly construction
+#define LAPACK_ORMQR    LAPACKE_dormqr  // LAPACK QR Q matrix multiples another matrix
+#define LAPACK_SYEVD    LAPACKE_dsyevd  // LAPACK eigenvalue decomposition
+#define N_DTYPE_64B     8               // 8 double == 64 bytes, for alignment
+#define SIMD_LEN        SIMD_LEN_D      // SIMD vector length
+#define ASTER_DTYPE_DOUBLE
+#endif
+
+
+#if DTYPE_SIZE == FLOAT_SIZE            // Marcos for float data type
+#define DTYPE           float
+#define DTYPE_FMTSTR    "%f"
+#define DABS            fabsf
+#define DLOG            logf
+#define DLOG2           log2f
+#define DEXP            expf
+#define DPOW            powf
+#define DSQRT           sqrtf
+#define DSIN            sinf
+#define DCOS            cosf
+#define DERF            erff
+#define DERFC           erfcf
+#define DFLOOR          floorf
+#define DROUND          roundf
+#define DFMOD           fmodf
+#define DCEIL           ceilf
+#define CBLAS_NRM2      cblas_snrm2
+#define CBLAS_DOT       cblas_sdot
+#define CBLAS_GEMV      cblas_sgemv
+#define CBLAS_GEMM      cblas_sgemm
+#define CBLAS_GER       cblas_sger
+#define CBLAS_TRSM      cblas_strsm
+#define LAPACK_GETRF    LAPACKE_sgetrf
+#define LAPACK_GETRS    LAPACKE_sgetrs
+#define LAPACK_GETRI    LAPACKE_sgetri
+#define LAPACK_POTRF    LAPACKE_spotrf
+#define LAPACK_POTRS    LAPACKE_spotrs
+#define LAPACK_GEQRF    LAPACKE_sgeqrf
+#define LAPACK_GEQPF    LAPACKE_sgeqpf
+#define LAPACK_ORGQR    LAPACKE_sorgqr
+#define LAPACK_ORMQR    LAPACKE_sormqr
+#define LAPACK_SYEVD    LAPACKE_ssyevd
+#define N_DTYPE_64B     16
+#define SIMD_LEN        SIMD_LEN_S
+#define ASTER_DTYPE_FLOAT
+#endif
+
+#define QR_RANK         0               // Partial QR stop criteria: maximum rank
+#define QR_REL_NRM      1               // Partial QR stop criteria: maximum relative column 2-norm
+#define QR_ABS_NRM      2               // Partial QR stop criteria: maximum absolute column 2-norm
+
+#define ALIGN_SIZE      64              // Memory allocation alignment
+#define ALPHA_H2        0.999999        // Admissible coefficient for H2,  == 1 here
+#define ALPHA_HSS       -0.000001       // Admissible coefficient for HSS, == 0 here
+
+#define BD_NTASK_THREAD 10              // Average number of tasks each thread has in B & D build
+
+#include "linalg_lib_wrapper.h"
+
+#endif

--- a/src/H2ERI_matvec.c
+++ b/src/H2ERI_matvec.c
@@ -5,12 +5,212 @@
 
 #include <omp.h>
 
-#include "H2Pack_matvec.h"
-#include "H2Pack_utils.h"
 #include "H2ERI_typedef.h"
 #include "H2ERI_matvec.h"
 #include "H2ERI_utils.h"
-#include "utils.h"  // In H2Pack
+#include "H2ERI_aux_structs.h"
+
+// Calculate GEMV A * x0 and A^T * x1 in one run to reduce bandwidth pressure
+// Input parameters:
+//   nrow   : Number of rows in the matrix
+//   ncol   : Number of columns in the matrix
+//   mat    : Matrix, size >= nrow * ldm
+//   ldm    : Leading dimension of the matrix, >= ncol
+//   x_in_0 : Input vector 0
+//   x_in_1 : Input vector 1
+// Output parameter:
+//   x_out_0 : Output vector 0, := mat   * x_in_0
+//   x_out_1 : Output vector 1, := mat^T * x_in_1
+static void CBLAS_BI_GEMV(
+    const int nrow, const int ncol, const DTYPE *mat, const int ldm,
+    const DTYPE *x_in_0, const DTYPE *x_in_1, DTYPE *x_out_0, DTYPE *x_out_1
+)
+{
+    const int nrow_2 = (nrow / 2) * 2;
+    for (int i = 0; i < nrow_2; i += 2)
+    {
+        const DTYPE *mat_irow0 = mat + (i + 0) * ldm;
+        const DTYPE *mat_irow1 = mat + (i + 1) * ldm;
+        const DTYPE x_in_1_i0 = x_in_1[i + 0];
+        const DTYPE x_in_1_i1 = x_in_1[i + 1];
+        DTYPE sum0 = 0, sum1 = 0;
+        #pragma omp simd
+        for (int j = 0; j < ncol; j++)
+        {
+            DTYPE x_in_0_j = x_in_0[j];
+            sum0 += mat_irow0[j] * x_in_0_j;
+            sum1 += mat_irow1[j] * x_in_0_j;
+            DTYPE tmp = x_in_1_i0 * mat_irow0[j];
+            tmp += x_in_1_i1 * mat_irow1[j];
+            x_out_1[j] += tmp;
+        }
+        x_out_0[i + 0] += sum0;
+        x_out_0[i + 1] += sum1;
+    }
+    for (int i = nrow_2; i < nrow; i++)
+    {
+        const DTYPE *mat_irow = mat + i * ldm;
+        const DTYPE x_in_1_i = x_in_1[i];
+        DTYPE sum = 0;
+        #pragma omp simd
+        for (int j = 0; j < ncol; j++)
+        {
+            sum += mat_irow[j] * x_in_0[j];
+            x_out_1[j] += x_in_1_i * mat_irow[j];
+        }
+        x_out_0[i] += sum;
+    }
+}
+
+// Initialize auxiliary array y0 used in H2 matvec forward transformation
+static void H2E_matvec_init_y0(H2ERI_p h2eri)
+{
+    if (h2eri->y0 != NULL) return;
+    int n_node = h2eri->n_node;
+    h2eri->y0 = (H2E_dense_mat_p*) malloc(sizeof(H2E_dense_mat_p) * n_node);
+    ASSERT_PRINTF(
+        h2eri->y0 != NULL, 
+        "Failed to allocate %d H2E_dense_mat_t for H2 matvec buffer\n", n_node
+    );
+    H2E_dense_mat_p *y0 = h2eri->y0;
+    H2E_dense_mat_p *U  = h2eri->U;
+    for (int node = 0; node < n_node; node++)
+    {
+        int ncol = U[node]->ncol;
+        if (ncol > 0) 
+        {
+            H2E_dense_mat_init(&y0[node], ncol, 1);
+        } else {
+            H2E_dense_mat_init(&y0[node], 0, 0);
+            y0[node]->nrow = 0;
+            y0[node]->ncol = 0;
+            y0[node]->ld   = 0;
+        }
+    }
+}
+
+// H2 matvec forward transformation, calculate U_j^T * x_j
+static void H2E_matvec_fwd_transform(H2ERI_p h2eri, const DTYPE *x)
+{
+    int n_thread       = h2eri->n_thread;
+    int max_child      = h2eri->max_child;
+    int n_leaf_node    = h2eri->n_leaf_node;
+    int max_level      = h2eri->max_level;
+    int min_adm_level  = h2eri->min_adm_level;
+    int *children      = h2eri->children;
+    int *n_child       = h2eri->n_child;
+    int *level_n_node  = h2eri->level_n_node;
+    int *level_nodes   = h2eri->level_nodes;
+    int *mat_cluster   = h2eri->mat_cluster;
+    H2E_thread_buf_p *thread_buf = h2eri->thread_buffs;
+    
+    H2E_matvec_init_y0(h2eri);
+
+    H2E_dense_mat_p *y0 = h2eri->y0;
+    H2E_dense_mat_p *U  = h2eri->U;
+    for (int i = max_level; i >= min_adm_level; i--)
+    {
+        int *level_i_nodes = level_nodes + i * n_leaf_node;
+        int level_i_n_node = level_n_node[i];
+        int n_thread_i = MIN(level_i_n_node, n_thread);
+        
+        #pragma omp parallel num_threads(n_thread_i)
+        {
+            int tid = omp_get_thread_num();
+            
+            thread_buf[tid]->timer = -get_wtime_sec();
+            #pragma omp for schedule(dynamic) nowait
+            for (int j = 0; j < level_i_n_node; j++)
+            {
+                int node = level_i_nodes[j];
+                int n_child_node = n_child[node];
+                H2E_dense_mat_p U_node = U[node];
+
+                H2E_dense_mat_resize(y0[node], U_node->ncol, 1);
+                if (n_child_node == 0)
+                {
+                    // Leaf node, directly calculate U_j^T * x_j
+                    const DTYPE *x_spos = x + mat_cluster[node * 2];
+                    CBLAS_GEMV(
+                        CblasRowMajor, CblasTrans, U_node->nrow, U_node->ncol, 
+                        1.0, U_node->data, U_node->ld, 
+                        x_spos, 1, 0.0, y0[node]->data, 1
+                    );
+                } else {
+                    // Non-leaf node, multiple U{node}^T with each child node y0 directly
+                    int *node_children = children + node * max_child;
+                    int U_srow = 0;
+                    for (int k = 0; k < n_child_node; k++)
+                    {
+                        int child_k = node_children[k];
+                        H2E_dense_mat_p y0_k = y0[child_k];
+                        DTYPE *U_node_k = U_node->data + U_srow * U_node->ld;
+                        DTYPE beta = (k == 0) ? 0.0 : 1.0;
+                        CBLAS_GEMV(
+                            CblasRowMajor, CblasTrans, y0_k->nrow, U_node->ncol, 
+                            1.0, U_node_k, U_node->ld, y0_k->data, 1, beta, y0[node]->data, 1
+                        );
+                        U_srow += y0_k->nrow;
+                    }
+                }  // End of "if (n_child_node == 0)"
+            }  // End of j loop
+            thread_buf[tid]->timer += get_wtime_sec();
+        }  // End of "pragma omp parallel"
+        
+        if (h2eri->print_timers == 1)
+        {
+            double max_t = 0.0, avg_t = 0.0, min_t = 19241112.0;
+            for (int i = 0; i < n_thread_i; i++)
+            {
+                double thread_i_timer = thread_buf[i]->timer;
+                avg_t += thread_i_timer;
+                max_t = MAX(max_t, thread_i_timer);
+                min_t = MIN(min_t, thread_i_timer);
+            }
+            avg_t /= (double) n_thread_i;
+            INFO_PRINTF("Matvec forward transformation: level %d, %d/%d threads, %d nodes\n", i, n_thread_i, n_thread, level_i_n_node);
+            INFO_PRINTF("    min/avg/max thread wall-time = %.3lf, %.3lf, %.3lf (s)\n", min_t, avg_t, max_t);
+        }
+    }  // End of i loop
+}
+
+// Initialize auxiliary array y1 used in H2 matvec intermediate multiplication
+static void H2E_matvec_init_y1(H2ERI_p h2eri)
+{
+    int n_node = h2eri->n_node;
+    int n_thread = h2eri->n_thread;
+    int *node_n_r_adm = h2eri->node_n_r_adm;
+    H2E_dense_mat_p *U = h2eri->U;
+    if (h2eri->y1 == NULL)
+    {
+        h2eri->y1 = (H2E_dense_mat_p*) malloc(sizeof(H2E_dense_mat_p) * n_node);
+        ASSERT_PRINTF(
+            h2eri->y1 != NULL,
+            "Failed to allocate %d H2E_dense_mat_t for H2 matvec buffer\n", n_node
+        );
+        for (int i = 0; i < n_node; i++) 
+            H2E_dense_mat_init(&h2eri->y1[i], 0, 0);
+    }
+    H2E_dense_mat_p *y1 = h2eri->y1;
+    // Use ld to mark if y1[i] is visited in this intermediate sweep
+    // The first U[i]->ncol elements in y1[i]->data will be used in downward sweep
+    for (int i = 0; i < n_node; i++) 
+    {
+        y1[i]->ld = 0;
+        if (node_n_r_adm[i]) H2E_dense_mat_resize(y1[i], n_thread, U[i]->ncol);
+    }
+    // Each thread set its y1 buffer to 0 (NUMA first touch)
+    #pragma omp parallel
+    {
+        int tid = omp_get_thread_num();
+        for (int i = 0; i < n_node; i++)
+        {
+            if (y1[i]->ld == 0) continue;
+            DTYPE *y1_i_thread = y1[i]->data + tid * y1[i]->ncol;
+            memset(y1_i_thread, 0, sizeof(DTYPE) * y1[i]->ncol);
+        }
+    }
+}
 
 // Perform bi-matvec for a B or D block blk which might be 
 // a dense block or a low-rank approximation blk = U * V.
@@ -22,8 +222,8 @@
 // Output parameters:
 //   x_out_0 : Array, size blk->nrow, == blk   * x_in_0
 //   x_out_1 : Array, size blk->ncol, == blk^T * x_in_1
-void H2ERI_BD_blk_bi_matvec(
-    H2P_dense_mat_p blk, H2P_dense_mat_p tmp_v,
+static void H2ERI_BD_blk_bi_matvec(
+    H2E_dense_mat_p blk, H2E_dense_mat_p tmp_v,
     const double *x_in_0, const double *x_in_1, 
     double *x_out_0, double *x_out_1
 )
@@ -41,7 +241,7 @@ void H2ERI_BD_blk_bi_matvec(
         int    blk_rank = -blk->ld;
         double *U_mat   = blk->data;
         double *VT_mat  = U_mat + blk->nrow * blk_rank;
-        H2P_dense_mat_resize(tmp_v, blk_rank, 1);
+        H2E_dense_mat_resize(tmp_v, blk_rank, 1);
         // x_out_0 = (U * V) * x_in_0 = U * V * x_in_0
         CBLAS_GEMV(
             CblasRowMajor, CblasTrans, blk->ncol, blk_rank, 
@@ -63,24 +263,54 @@ void H2ERI_BD_blk_bi_matvec(
     }
 }
 
+// Sum thread-local buffers to obtain final y1 results
+static void H2E_matvec_sum_y1_thread(H2ERI_p h2eri)
+{
+    int n_node = h2eri->n_node;
+    int n_thread = h2eri->n_thread;
+    H2E_dense_mat_p *y1 = h2eri->y1;
+    H2E_thread_buf_p *thread_buf = h2eri->thread_buffs;
+    
+    #pragma omp parallel num_threads(n_thread)
+    {
+        int tid = omp_get_thread_num();
+        
+        thread_buf[tid]->timer -= get_wtime_sec();
+        #pragma omp for schedule(dynamic) nowait
+        for (int i = 0; i < n_node; i++)
+        {
+            if (y1[i]->ld == 0) continue;
+            int ncol = y1[i]->ncol;
+            DTYPE *dst_row = y1[i]->data;
+            for (int j = 1; j < n_thread; j++)
+            {
+                DTYPE *src_row = y1[i]->data + j * ncol;
+                #pragma omp simd
+                for (int k = 0; k < ncol; k++)
+                    dst_row[k] += src_row[k];
+            }
+        }
+        thread_buf[tid]->timer += get_wtime_sec();
+    }
+}
+
 // H2 matvec intermediate multiplication for H2ERI
 // All B_{ij} matrices are calculated and stored
 void H2ERI_matvec_intmd_mult_AOT(H2ERI_p h2eri, const double *x)
 {
-    H2Pack_p h2pack  = h2eri->h2pack;
-    int n_node       = h2pack->n_node;
-    int n_thread     = h2pack->n_thread;
-    int *r_adm_pairs = h2pack->r_adm_pairs;
-    int *node_level  = h2pack->node_level;
-    int *mat_cluster = h2pack->mat_cluster;
-    H2P_int_vec_p   B_blk        = h2pack->B_blk;
-    H2P_dense_mat_p *y0          = h2pack->y0;
-    H2P_thread_buf_p *thread_buf = h2pack->tb;
-    H2P_dense_mat_p  *c_B_blks   = h2eri->c_B_blks;
+    int n_node       = h2eri->n_node;
+    int n_thread     = h2eri->n_thread;
+    int *r_adm_pairs = h2eri->r_adm_pairs;
+    int *node_level  = h2eri->node_level;
+    int *mat_cluster = h2eri->mat_cluster;
+    H2E_int_vec_p   B_blk        = h2eri->B_blk;
+    H2E_dense_mat_p *y0          = h2eri->y0;
+    H2E_thread_buf_p *thread_buf = h2eri->thread_buffs;
+    H2E_dense_mat_p  *c_B_blks   = h2eri->c_B_blks;
     
     // 1. Initialize y1 
-    H2P_matvec_init_y1(h2pack);
-    H2P_dense_mat_p *y1 = h2pack->y1;
+    H2E_matvec_init_y1(h2eri);
+    H2E_dense_mat_p *y1 = h2eri->y1;
     
     // 2. Intermediate multiplication
     const int n_B_blk = B_blk->length - 1;
@@ -90,7 +320,7 @@ void H2ERI_matvec_intmd_mult_AOT(H2ERI_p h2eri, const double *x)
         double *y = thread_buf[tid]->y;
         thread_buf[tid]->timer = -get_wtime_sec();
         
-        H2P_dense_mat_p tmp_v = thread_buf[tid]->mat0;
+        H2E_dense_mat_p tmp_v = thread_buf[tid]->mat0;
         
         #pragma omp for schedule(dynamic) nowait
         for (int i_blk = 0; i_blk < n_B_blk; i_blk++)
@@ -104,7 +334,7 @@ void H2ERI_matvec_intmd_mult_AOT(H2ERI_p h2eri, const double *x)
                 int level0 = node_level[node0];
                 int level1 = node_level[node1];
                 
-                H2P_dense_mat_p Bi = c_B_blks[i];
+                H2E_dense_mat_p Bi = c_B_blks[i];
                 
                 // (1) Two nodes are of the same level, compress on both sides
                 if (level0 == level1)
@@ -160,7 +390,7 @@ void H2ERI_matvec_intmd_mult_AOT(H2ERI_p h2eri, const double *x)
     }  // End of "pragma omp parallel"
     
     // 3. Sum thread-local buffers in y1
-    H2P_matvec_sum_y1_thread(h2pack);
+    H2E_matvec_sum_y1_thread(h2eri);
     
     #ifdef PROFILING_OUTPUT
     double max_t = 0.0, avg_t = 0.0, min_t = 19241112.0;
@@ -180,29 +410,28 @@ void H2ERI_matvec_intmd_mult_AOT(H2ERI_p h2eri, const double *x)
 // Need to calculate all B_{ij} matrices before using it
 void H2ERI_matvec_intmd_mult_JIT(H2ERI_p h2eri, const double *x)
 {
-    H2Pack_p h2pack = h2eri->h2pack;
-    int n_node            = h2pack->n_node;
-    int n_thread          = h2pack->n_thread;
-    int *r_adm_pairs      = h2pack->r_adm_pairs;
-    int *node_level       = h2pack->node_level;
-    int *pt_cluster       = h2pack->pt_cluster;
-    int *mat_cluster      = h2pack->mat_cluster;
+    int n_node            = h2eri->n_node;
+    int n_thread          = h2eri->n_thread;
+    int *r_adm_pairs      = h2eri->r_adm_pairs;
+    int *node_level       = h2eri->node_level;
+    int *pt_cluster       = h2eri->pt_cluster;
+    int *mat_cluster      = h2eri->mat_cluster;
     int *sp_nbfp          = h2eri->sp_nbfp;
     int *index_seq        = h2eri->index_seq;
-    int *B_nrow           = h2pack->B_nrow;
-    int *B_ncol           = h2pack->B_ncol;
+    int *B_nrow           = h2eri->B_nrow;
+    int *B_ncol           = h2eri->B_ncol;
     multi_sp_t    *sp     = h2eri->sp;
-    H2P_int_vec_p B_blk   = h2pack->B_blk;
-    H2P_int_vec_p *J_pair = h2eri->J_pair;
-    H2P_int_vec_p *J_row  = h2eri->J_row;
-    H2P_dense_mat_p *y0   = h2pack->y0;
-    H2P_thread_buf_p *thread_buf      = h2pack->tb;
+    H2E_int_vec_p B_blk   = h2eri->B_blk;
+    H2E_int_vec_p *J_pair = h2eri->J_pair;
+    H2E_int_vec_p *J_row  = h2eri->J_row;
+    H2E_dense_mat_p *y0   = h2eri->y0;
+    H2E_thread_buf_p *thread_buf      = h2eri->thread_buffs;
     simint_buff_p    *simint_buffs    = h2eri->simint_buffs;
     eri_batch_buff_p *eri_batch_buffs = h2eri->eri_batch_buffs;
     
     // 1. Initialize y1 
-    H2P_matvec_init_y1(h2pack);
-    H2P_dense_mat_p *y1 = h2pack->y1;
+    H2E_matvec_init_y1(h2eri);
+    H2E_dense_mat_p *y1 = h2eri->y1;
     
     // 2. Intermediate multiplication
     const int n_B_blk = B_blk->length - 1;
@@ -210,7 +439,7 @@ void H2ERI_matvec_intmd_mult_JIT(H2ERI_p h2eri, const double *x)
     {
         int tid = omp_get_thread_num();
         
-        H2P_dense_mat_p  tmpB           = thread_buf[tid]->mat0;
+        H2E_dense_mat_p  tmpB           = thread_buf[tid]->mat0;
         simint_buff_p    simint_buff    = simint_buffs[tid];
         eri_batch_buff_p eri_batch_buff = eri_batch_buffs[tid];
         
@@ -239,13 +468,13 @@ void H2ERI_matvec_intmd_mult_JIT(H2ERI_p h2eri, const double *x)
                     int n_ket_pair = J_pair[node1]->length;
                     int *bra_idx   = J_pair[node0]->data;
                     int *ket_idx   = J_pair[node1]->data;
-                    H2P_dense_mat_resize(tmpB, tmpB_nrow, tmpB_ncol);
+                    H2E_dense_mat_resize(tmpB, tmpB_nrow, tmpB_ncol);
                     H2ERI_calc_ERI_pairs_to_mat(
                         sp, n_bra_pair, n_ket_pair, bra_idx, ket_idx, 
                         simint_buff, tmpB->data, tmpB->ncol, eri_batch_buff
                     );
-                    H2P_dense_mat_select_rows   (tmpB, J_row[node0]);
-                    H2P_dense_mat_select_columns(tmpB, J_row[node1]);
+                    H2E_dense_mat_select_rows   (tmpB, J_row[node0]);
+                    H2E_dense_mat_select_columns(tmpB, J_row[node1]);
                     
                     int ncol0 = y1[node0]->ncol;
                     int ncol1 = y1[node1]->ncol;
@@ -269,12 +498,12 @@ void H2ERI_matvec_intmd_mult_JIT(H2ERI_p h2eri, const double *x)
                     int n_ket_pair = pt_e1 - pt_s1 + 1;
                     int *bra_idx   = J_pair[node0]->data;
                     int *ket_idx   = index_seq + pt_s1;
-                    H2P_dense_mat_resize(tmpB, tmpB_nrow, tmpB_ncol);
+                    H2E_dense_mat_resize(tmpB, tmpB_nrow, tmpB_ncol);
                     H2ERI_calc_ERI_pairs_to_mat(
                         sp, n_bra_pair, n_ket_pair, bra_idx, ket_idx, 
                         simint_buff, tmpB->data, tmpB->ncol, eri_batch_buff
                     );
-                    H2P_dense_mat_select_rows(tmpB, J_row[node0]);
+                    H2E_dense_mat_select_rows(tmpB, J_row[node0]);
                     
                     int vec_s1 = mat_cluster[node1 * 2];
                     double       *y_spos = y + vec_s1;
@@ -299,12 +528,12 @@ void H2ERI_matvec_intmd_mult_JIT(H2ERI_p h2eri, const double *x)
                     int n_ket_pair = J_pair[node1]->length;
                     int *bra_idx   = index_seq + pt_s0;
                     int *ket_idx   = J_pair[node1]->data;
-                    H2P_dense_mat_resize(tmpB, tmpB_nrow, tmpB_ncol);
+                    H2E_dense_mat_resize(tmpB, tmpB_nrow, tmpB_ncol);
                     H2ERI_calc_ERI_pairs_to_mat(
                         sp, n_bra_pair, n_ket_pair, bra_idx, ket_idx, 
                         simint_buff, tmpB->data, tmpB->ncol, eri_batch_buff
                     );
-                    H2P_dense_mat_select_columns(tmpB, J_row[node1]);
+                    H2E_dense_mat_select_columns(tmpB, J_row[node1]);
                     
                     int vec_s0 = mat_cluster[node0 * 2];
                     double       *y_spos = y + vec_s0;
@@ -322,7 +551,7 @@ void H2ERI_matvec_intmd_mult_JIT(H2ERI_p h2eri, const double *x)
     }  // End of "pragma omp parallel"
     
     // 3. Sum thread-local buffers in y1
-    H2P_matvec_sum_y1_thread(h2pack);
+    H2E_matvec_sum_y1_thread(h2eri);
     
     #ifdef PROFILING_OUTPUT
     double max_t = 0.0, avg_t = 0.0, min_t = 19241112.0;
@@ -340,18 +569,17 @@ void H2ERI_matvec_intmd_mult_JIT(H2ERI_p h2eri, const double *x)
 
 // H2 matvec dense multiplication for H2ERI
 // All D_{ij} matrices are calculated and stored
-void H2ERI_matvec_dense_mult_AOT(H2ERI_p h2eri, const double *x)
+static void H2ERI_matvec_dense_mult_AOT(H2ERI_p h2eri, const double *x)
 {
-    H2Pack_p h2pack    = h2eri->h2pack;
-    int n_thread       = h2pack->n_thread;
-    int n_leaf_node    = h2pack->n_leaf_node;
-    int *leaf_nodes    = h2pack->height_nodes;
-    int *mat_cluster   = h2pack->mat_cluster;
-    int *r_inadm_pairs = h2pack->r_inadm_pairs;
-    H2P_int_vec_p    D_blk0      = h2pack->D_blk0;
-    H2P_int_vec_p    D_blk1      = h2pack->D_blk1;
-    H2P_thread_buf_p *thread_buf = h2pack->tb;
-    H2P_dense_mat_p  *c_D_blks   = h2eri->c_D_blks;
+    int n_thread       = h2eri->n_thread;
+    int n_leaf_node    = h2eri->n_leaf_node;
+    int *leaf_nodes    = h2eri->height_nodes;
+    int *mat_cluster   = h2eri->mat_cluster;
+    int *r_inadm_pairs = h2eri->r_inadm_pairs;
+    H2E_int_vec_p    D_blk0      = h2eri->D_blk0;
+    H2E_int_vec_p    D_blk1      = h2eri->D_blk1;
+    H2E_thread_buf_p *thread_buf = h2eri->thread_buffs;
+    H2E_dense_mat_p  *c_D_blks   = h2eri->c_D_blks;
     
     const int n_D0_blk = D_blk0->length - 1;
     const int n_D1_blk = D_blk1->length - 1;
@@ -360,8 +588,8 @@ void H2ERI_matvec_dense_mult_AOT(H2ERI_p h2eri, const double *x)
         int tid = omp_get_thread_num();
         
         double *y = thread_buf[tid]->y;
-        H2P_dense_mat_p tmp_v  = thread_buf[tid]->mat0;
-        H2P_dense_mat_p tmp_v2 = thread_buf[tid]->mat1;
+        H2E_dense_mat_p tmp_v  = thread_buf[tid]->mat0;
+        H2E_dense_mat_p tmp_v2 = thread_buf[tid]->mat1;
 
         thread_buf[tid]->timer = -get_wtime_sec();
         
@@ -373,13 +601,13 @@ void H2ERI_matvec_dense_mult_AOT(H2ERI_p h2eri, const double *x)
             int D_blk0_e = D_blk0->data[i_blk0 + 1];
             for (int i = D_blk0_s; i < D_blk0_e; i++)
             {
-                H2P_dense_mat_p Di = c_D_blks[i];
+                H2E_dense_mat_p Di = c_D_blks[i];
                 int node  = leaf_nodes[i];
                 int vec_s = mat_cluster[node * 2];
                 double       *y_spos = y + vec_s;
                 const double *x_spos = x + vec_s;
 
-                H2P_dense_mat_resize(tmp_v2, 1, Di->nrow + Di->ncol);
+                H2E_dense_mat_resize(tmp_v2, 1, Di->nrow + Di->ncol);
                 const double *x_in_0 = x_spos;
                 const double *x_in_1 = tmp_v2->data;
                 double *x_out_0 = y_spos;
@@ -396,7 +624,7 @@ void H2ERI_matvec_dense_mult_AOT(H2ERI_p h2eri, const double *x)
             int D_blk1_e = D_blk1->data[i_blk1 + 1];
             for (int i = D_blk1_s; i < D_blk1_e; i++)
             {
-                H2P_dense_mat_p Di = c_D_blks[i + n_leaf_node];
+                H2E_dense_mat_p Di = c_D_blks[i + n_leaf_node];
                 int node0  = r_inadm_pairs[2 * i];
                 int node1  = r_inadm_pairs[2 * i + 1];
                 int vec_s0 = mat_cluster[2 * node0];
@@ -431,24 +659,120 @@ void H2ERI_matvec_dense_mult_AOT(H2ERI_p h2eri, const double *x)
     #endif
 }
 
+// H2 matvec backward transformation, calculate U_i * (B_{ij} * (U_j^T * x_j))
+static void H2E_matvec_bwd_transform(H2ERI_p h2eri, const DTYPE *x, DTYPE *y)
+{
+    int n_thread        = h2eri->n_thread;
+    int max_child       = h2eri->max_child;
+    int n_leaf_node     = h2eri->n_leaf_node;
+    int max_level       = h2eri->max_level;
+    int min_adm_level   = h2eri->min_adm_level;
+    int *children       = h2eri->children;
+    int *n_child        = h2eri->n_child;
+    int *level_n_node   = h2eri->level_n_node;
+    int *level_nodes    = h2eri->level_nodes;
+    int *mat_cluster    = h2eri->mat_cluster;
+    H2E_dense_mat_p *U  = h2eri->U;
+    H2E_dense_mat_p *y1 = h2eri->y1;
+    H2E_thread_buf_p *thread_buf = h2eri->thread_buffs;
+    
+    for (int i = min_adm_level; i <= max_level; i++)
+    {
+        int *level_i_nodes = level_nodes + i * n_leaf_node;
+        int level_i_n_node = level_n_node[i];
+        int n_thread_i = MIN(level_i_n_node, n_thread);
+        
+        #pragma omp parallel num_threads(n_thread_i) 
+        {
+            int tid = omp_get_thread_num();
+            H2E_dense_mat_p y1_tmp = thread_buf[tid]->mat0;
+            
+            thread_buf[tid]->timer = -get_wtime_sec();
+            #pragma omp for schedule(dynamic) nowait
+            for (int j = 0; j < level_i_n_node; j++)
+            {
+                int node = level_i_nodes[j];
+                int n_child_node = n_child[node];
+                int *child_nodes = children + node * max_child;
+                
+                if (y1[node]->ld == 0) continue;
+                
+                H2E_dense_mat_resize(y1_tmp, U[node]->nrow, 1);
+                
+                CBLAS_GEMV(
+                    CblasRowMajor, CblasNoTrans, U[node]->nrow, U[node]->ncol,
+                    1.0, U[node]->data, U[node]->ld, 
+                    y1[node]->data, 1, 0.0, y1_tmp->data, 1
+                );
+                
+                if (n_child_node == 0)
+                {
+                    // Leaf node, accumulate final results to output vector
+                    int s_index = mat_cluster[2 * node];
+                    int e_index = mat_cluster[2 * node + 1];
+                    int n_point = e_index - s_index + 1;
+                    DTYPE *y_spos = y + s_index;
+                    #pragma omp simd
+                    for (int k = 0; k < n_point; k++)
+                        y_spos[k] += y1_tmp->data[k];
+                } else {
+                    // Non-leaf node, push down y1 values
+                    int y1_tmp_idx = 0;
+                    for (int k = 0; k < n_child_node; k++)
+                    {
+                        int child_k = child_nodes[k];
+                        int child_k_len = U[child_k]->ncol;
+                        DTYPE *y1_tmp_spos = y1_tmp->data + y1_tmp_idx;
+                        if (y1[child_k]->ld == 0)
+                        {
+                            H2E_dense_mat_resize(y1[child_k], child_k_len, 1);
+                            memcpy(y1[child_k]->data, y1_tmp_spos, sizeof(DTYPE) * child_k_len);
+                        } else {
+                            #pragma omp simd
+                            for (int l = 0; l < child_k_len; l++)
+                                y1[child_k]->data[l] += y1_tmp_spos[l];
+                        }
+                        y1_tmp_idx += child_k_len;
+                    }
+                }  // End of "if (n_child_node == 0)"
+            }  // End of j loop
+            thread_buf[tid]->timer += get_wtime_sec();
+        }  // End of "pragma omp parallel"
+        
+        if (h2eri->print_timers == 1)
+        {
+            double max_t = 0.0, avg_t = 0.0, min_t = 19241112.0;
+            for (int i = 0; i < n_thread_i; i++)
+            {
+                double thread_i_timer = thread_buf[i]->timer;
+                avg_t += thread_i_timer;
+                max_t = MAX(max_t, thread_i_timer);
+                min_t = MIN(min_t, thread_i_timer);
+            }
+            avg_t /= (double) n_thread_i;
+            INFO_PRINTF("Matvec backward transformation: level %d, %d/%d threads, %d nodes\n", i, n_thread_i, n_thread, level_i_n_node);
+            INFO_PRINTF("    min/avg/max thread wall-time = %.3lf, %.3lf, %.3lf (s)\n", min_t, avg_t, max_t);
+        }  // End of "if (h2eri->print_timers == 1)"
+    }  // End of i loop
+}
+
 // H2 matvec dense multiplication for H2ERI
 // Need to calculate all D_{ij} matrices before using it
-void H2ERI_matvec_dense_mult_JIT(H2ERI_p h2eri, const double *x)
+static void H2ERI_matvec_dense_mult_JIT(H2ERI_p h2eri, const double *x)
 {
-    H2Pack_p h2pack = h2eri->h2pack;
-    int n_thread         = h2pack->n_thread;
-    int n_leaf_node      = h2pack->n_leaf_node;
-    int *pt_cluster      = h2pack->pt_cluster;
-    int *leaf_nodes      = h2pack->height_nodes;
-    int *mat_cluster     = h2pack->mat_cluster;
-    int *r_inadm_pairs   = h2pack->r_inadm_pairs;
-    int *D_nrow          = h2pack->D_nrow;
-    int *D_ncol          = h2pack->D_ncol;
+    int n_thread         = h2eri->n_thread;
+    int n_leaf_node      = h2eri->n_leaf_node;
+    int *pt_cluster      = h2eri->pt_cluster;
+    int *leaf_nodes      = h2eri->height_nodes;
+    int *mat_cluster     = h2eri->mat_cluster;
+    int *r_inadm_pairs   = h2eri->r_inadm_pairs;
+    int *D_nrow          = h2eri->D_nrow;
+    int *D_ncol          = h2eri->D_ncol;
     int *index_seq       = h2eri->index_seq;
-    H2P_int_vec_p D_blk0 = h2pack->D_blk0;
-    H2P_int_vec_p D_blk1 = h2pack->D_blk1;
+    H2E_int_vec_p D_blk0 = h2eri->D_blk0;
+    H2E_int_vec_p D_blk1 = h2eri->D_blk1;
     multi_sp_t *sp       = h2eri->sp;
-    H2P_thread_buf_p *thread_buf      = h2pack->tb;
+    H2E_thread_buf_p *thread_buf      = h2eri->thread_buffs;
     simint_buff_p    *simint_buffs    = h2eri->simint_buffs;
     eri_batch_buff_p *eri_batch_buffs = h2eri->eri_batch_buffs;
     
@@ -458,7 +782,7 @@ void H2ERI_matvec_dense_mult_JIT(H2ERI_p h2eri, const double *x)
     {
         int tid = omp_get_thread_num();
         
-        H2P_dense_mat_p  tmpD           = thread_buf[tid]->mat0;
+        H2E_dense_mat_p  tmpD           = thread_buf[tid]->mat0;
         simint_buff_p    simint_buff    = simint_buffs[tid];
         eri_batch_buff_p eri_batch_buff = eri_batch_buffs[tid];
         
@@ -482,7 +806,7 @@ void H2ERI_matvec_dense_mult_JIT(H2ERI_p h2eri, const double *x)
                 int Di_ncol   = D_ncol[i];
                 int *bra_idx  = index_seq + pt_s;
                 int *ket_idx  = bra_idx;
-                H2P_dense_mat_resize(tmpD, Di_nrow, Di_ncol);
+                H2E_dense_mat_resize(tmpD, Di_nrow, Di_ncol);
                 H2ERI_calc_ERI_pairs_to_mat(
                     sp, node_npts, node_npts, bra_idx, ket_idx, 
                     simint_buff, tmpD->data, Di_ncol, eri_batch_buff
@@ -518,7 +842,7 @@ void H2ERI_matvec_dense_mult_JIT(H2ERI_p h2eri, const double *x)
                 int Di_ncol    = D_ncol[i + n_leaf_node];
                 int *bra_idx   = index_seq + pt_s0;
                 int *ket_idx   = index_seq + pt_s1;
-                H2P_dense_mat_resize(tmpD, Di_nrow, Di_ncol);
+                H2E_dense_mat_resize(tmpD, Di_nrow, Di_ncol);
                 H2ERI_calc_ERI_pairs_to_mat(
                     sp, node0_npts, node1_npts, bra_idx, ket_idx, 
                     simint_buff, tmpD->data, Di_ncol, eri_batch_buff
@@ -557,10 +881,9 @@ void H2ERI_matvec_dense_mult_JIT(H2ERI_p h2eri, const double *x)
 // H2 representation for an ERI tensor multiplies a column vector
 void H2ERI_matvec(H2ERI_p h2eri, const double *x, double *y)
 {
-    H2Pack_p h2pack   = h2eri->h2pack;
-    int krnl_mat_size = h2pack->krnl_mat_size;
-    int n_thread      = h2pack->n_thread;
-    H2P_thread_buf_p *thread_buf = h2pack->tb;
+    int krnl_mat_size = h2eri->krnl_mat_size;
+    int n_thread      = h2eri->n_thread;
+    H2E_thread_buf_p *thread_buf = h2eri->thread_buffs;
     double st, et;
     
     // 1. Reset partial y result in each thread-local buffer to 0
@@ -575,41 +898,41 @@ void H2ERI_matvec(H2ERI_p h2eri, const double *x, double *y)
         for (int i = 0; i < krnl_mat_size; i++) y[i] = 0;
     }
     et = get_wtime_sec();
-    h2pack->timers[MV_VOP_TIMER_IDX] += et - st;
+    h2eri->timers[MV_VOP_TIMER_IDX] += et - st;
     
     // 2. Forward transformation, calculate U_j^T * x_j
     st = get_wtime_sec();
-    H2P_matvec_fwd_transform(h2pack, x);
+    H2E_matvec_fwd_transform(h2eri, x);
     et = get_wtime_sec();
-    h2pack->timers[MV_FWD_TIMER_IDX] += et - st;
+    h2eri->timers[MV_FWD_TIMER_IDX] += et - st;
     
     // 3. Intermediate multiplication, calculate B_{ij} * (U_j^T * x_j)
     st = get_wtime_sec();
-    if (h2eri->h2pack->BD_JIT == 0)
+    if (h2eri->BD_JIT == 0)
     {
         H2ERI_matvec_intmd_mult_AOT(h2eri, x);
     } else {
         H2ERI_matvec_intmd_mult_JIT(h2eri, x);
     }
     et = get_wtime_sec();
-    h2pack->timers[MV_MID_TIMER_IDX] += et - st;
+    h2eri->timers[MV_MID_TIMER_IDX] += et - st;
     
     // 4. Backward transformation, calculate U_i * (B_{ij} * (U_j^T * x_j))
     st = get_wtime_sec();
-    H2P_matvec_bwd_transform(h2pack, x, y);
+    H2E_matvec_bwd_transform(h2eri, x, y);
     et = get_wtime_sec();
-    h2pack->timers[MV_BWD_TIMER_IDX] += et - st;
+    h2eri->timers[MV_BWD_TIMER_IDX] += et - st;
     
     // 5. Dense multiplication, calculate D_i * x_i
     st = get_wtime_sec();
-    if (h2eri->h2pack->BD_JIT == 0)
+    if (h2eri->BD_JIT == 0)
     {
         H2ERI_matvec_dense_mult_AOT(h2eri, x);
     } else {
         H2ERI_matvec_dense_mult_JIT(h2eri, x);
     }
     et = get_wtime_sec();
-    h2pack->timers[MV_DEN_TIMER_IDX] += et - st;
+    h2eri->timers[MV_DEN_TIMER_IDX] += et - st;
     
     // 6. Reduce sum partial y results
     st = get_wtime_sec();
@@ -626,9 +949,9 @@ void H2ERI_matvec(H2ERI_p h2eri, const double *x, double *y)
             for (int i = spos; i < spos + len; i++) y[i] += y_src[i];
         }
     }
-    h2pack->mat_size[MV_VOP_SIZE_IDX] = (2 * n_thread + 1) * h2pack->krnl_mat_size;
+    h2eri->mat_size[MV_VOP_SIZE_IDX] = (2 * n_thread + 1) * h2eri->krnl_mat_size;
     et = get_wtime_sec();
-    h2pack->timers[MV_VOP_TIMER_IDX] += et - st;
+    h2eri->timers[MV_VOP_TIMER_IDX] += et - st;
     
-    h2pack->n_matvec++;
+    h2eri->n_matvec++;
 }

--- a/src/H2ERI_partition.h
+++ b/src/H2ERI_partition.h
@@ -15,15 +15,14 @@ extern "C" {
 //   h2eri->sp_center : Array, size 3 * num_sp, centers of SSP
 //   h2eri->sp_extent : Array, size num_sp, extents of SSP
 // Output parameters:
-//   h2eri->h2pack        : H2Pack structure with point partitioning info
 //   h2eri->sp_center     : Array, size 3 * num_sp, sorted centers of SSP
 //   h2eri->sp_extent     : Array, size num_sp, sorted extents of SSP
 //   h2eri->shell_bf_sidx : Array, size nshell, indices of each shell's first basis function
 //   h2eri->sp_nbfp       : Array, size num_sp, number of basis function pairs of each SSP
 //   h2eri->sp_bfp_sidx   : Array, size num_sp+1, indices of each SSP first basis function pair
-//   h2eri->box_extent    : Array, size h2pack->n_node, extent of each H2 node box
-//   h2pack->mat_cluster  : Array, size h2pack->n_node * 2, matvec cluster for H2 nodes
-//   h2eri->simint_buffs  : Array, size h2pack->n_thread, thread local Simint ERI buffers
+//   h2eri->box_extent    : Array, size h2eri->n_node, extent of each H2 node box
+//   h2eri->mat_cluster   : Array, size h2eri->n_node * 2, matvec cluster for H2 nodes
+//   h2eri->simint_buffs  : Array, size h2eri->n_thread, thread local Simint ERI buffers
 //   h2eri->sp_shells     : Array, size 2 * num_sp, each column is a SSP
 //   h2eri->sp            : Array, size num_sp, all screened shell pairs
 void H2ERI_partition(H2ERI_p h2eri);

--- a/src/H2ERI_partition_points.c
+++ b/src/H2ERI_partition_points.c
@@ -1,0 +1,548 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <math.h>
+#include <omp.h>
+
+#include "H2ERI_typedef.h"
+#include "H2ERI_aux_structs.h"
+#include "H2ERI_utils.h"
+#include "H2ERI_partition.h"
+
+// Hierarchical partitioning of the given points.
+// Tree nodes are indexed in post order.
+// Input parameters:
+//   level           : Level of current node (root == 0)
+//   coord_s         : Index of the first point in this box
+//   coord_e         : Index of the last point in this box
+//   pt_dim          : Dimension of point coordinate
+//   xpt_dim         : Dimension of extended point coordinate (for RPY)
+//   n_point         : Total number of points
+//   max_leaf_size   : Maximum box size for leaf nodes
+//   max_leaf_points : Maximum number of points for leaf nodes
+//   enbox           : Box that encloses all points in this node. 
+//                     enbox[0 : pt_dim-1] are the corner with the smallest
+//                     x/y/z/... coordinates. enbox[pt_dim : 2*pt_dim-1] are  
+//                     the sizes of this box.
+//   coord           : Array, size n_point * pt_dim, point coordinates.
+//   coord_tmp       : Temporary array for sorting coord
+//   coord_idx       : Array, size n_point, original index of each point
+//   coord_idx_tmp   : Temporary array for sorting coord_idx
+//   part_vars       : Structure for storing working variables and arrays in point partitioning
+// Output parameters:
+//   coord           : Sorted coordinates
+//   <return>        : Information of current node
+H2E_tree_node_p H2E_bisection_partition_points(
+    int level, int coord_s, int coord_e, const int pt_dim, const int xpt_dim, const int n_point, 
+    const DTYPE max_leaf_size, const int max_leaf_points, DTYPE *enbox, 
+    DTYPE *coord, DTYPE *coord_tmp, int *coord_idx, int *coord_idx_tmp, 
+    H2E_partition_vars_p part_vars
+)
+{
+    int node_npts = coord_e - coord_s + 1;
+    int max_child = 1 << pt_dim;
+    if (level > part_vars->max_level) part_vars->max_level = level;
+    
+    // 1. Check the enclosing box
+    int alloc_enbox = 0;
+    if (enbox == NULL)
+    {
+        alloc_enbox = 1;
+        enbox = (DTYPE*) malloc(sizeof(DTYPE) * pt_dim * 2);
+        DTYPE *center = (DTYPE*) malloc(sizeof(DTYPE) * pt_dim);
+        memset(center, 0, sizeof(DTYPE) * pt_dim);
+        // Calculate the center of points in this box
+        for (int j = 0; j < pt_dim; j++)
+        {
+            DTYPE *coord_dim_j = coord + j * n_point;
+            for (int i = coord_s; i <= coord_e; i++)
+                center[j] += coord_dim_j[i];
+        }
+        DTYPE semi_box_size = 0.0;
+        DTYPE npts = (DTYPE) node_npts;
+        for (int j = 0; j < pt_dim; j++) center[j] /= npts;
+        // Calculate the box size
+        for (int j = 0; j < pt_dim; j++)
+        {
+            DTYPE *coord_dim_j = coord + j * n_point;
+            DTYPE center_j = center[j];
+            for (int i = coord_s; i <= coord_e; i++)
+            {
+                DTYPE tmp = DABS(coord_dim_j[i] - center_j);
+                semi_box_size = MAX(semi_box_size, tmp);
+            }
+        }
+        semi_box_size = semi_box_size + 1e-8;
+        // Give the center a small random shift to prevent highly symmetric point distributions
+        // Use a fixed random seed here to get the same partitioning for repeated tests
+        DTYPE shift_scale = semi_box_size * 1e-3;
+        srand48(19241112);
+        for (int j = 0; j < pt_dim; j++) 
+        {
+            DTYPE shift_j = (DTYPE) drand48() * 0.5 + 0.25;
+            center[j] += shift_j * shift_scale;
+        }
+        // Recalculate the box size
+        semi_box_size = 0.0;
+        for (int j = 0; j < pt_dim; j++)
+        {
+            DTYPE *coord_dim_j = coord + j * n_point;
+            DTYPE center_j = center[j];
+            for (int i = coord_s; i <= coord_e; i++)
+            {
+                DTYPE tmp = DABS(coord_dim_j[i] - center_j);
+                semi_box_size = MAX(semi_box_size, tmp);
+            }
+        }
+        semi_box_size = semi_box_size + 1e-8;
+        for (int j = 0; j < pt_dim; j++)
+        {
+            enbox[j] = center[j] - semi_box_size - 2e-12;
+            enbox[pt_dim + j] = 2 * semi_box_size + 4e-12;
+        }
+        free(center);
+    }  // End of "if (enbox == NULL)"
+    DTYPE box_size = enbox[pt_dim];
+    
+    // 2. If the size of current box or the number of points in current box
+    //    is smaller than the threshold, set current box as a leaf node
+    if ((node_npts <= max_leaf_points) || (box_size <= max_leaf_size))
+    {
+        H2E_tree_node_p node;
+        H2E_tree_node_init(&node, pt_dim);
+        node->pt_cluster[0] = coord_s;
+        node->pt_cluster[1] = coord_e;
+        node->n_child = 0;
+        node->n_node  = 1;
+        node->po_idx  = part_vars->curr_po_idx;
+        node->level   = level;
+        node->height  = 0;
+        memcpy(node->enbox, enbox, sizeof(DTYPE) * pt_dim * 2);
+        part_vars->curr_po_idx++;
+        part_vars->n_leaf_node++;
+        if (alloc_enbox) free(enbox);
+        return node;
+    }
+    
+    // 3. Bisection partition points in current box
+    int *rel_idx   = (int*) malloc(sizeof(int) * node_npts * pt_dim);
+    int *child_idx = (int*) malloc(sizeof(int) * node_npts);
+    ASSERT_PRINTF(
+        rel_idx != NULL && child_idx != NULL, 
+        "Failed to allocate index arrays of size %d for bisection partitioning\n", node_npts * (pt_dim + 1)
+    );
+    memset(child_idx, 0, sizeof(int) * node_npts);
+    int pow2 = 1;
+    for (int j = 0; j < pt_dim; j++)
+    {
+        DTYPE enbox_corner_j = enbox[j];
+        DTYPE enbox_width_j  = enbox[pt_dim + j];
+        DTYPE *coord_dim_j_s = coord   + j * n_point + coord_s;
+        int   *rel_idx_dim_j = rel_idx + j * node_npts;
+        for (int i = 0; i < node_npts; i++)
+        {
+            DTYPE rel_coord  = coord_dim_j_s[i] - enbox_corner_j;
+            rel_idx_dim_j[i] = DFLOOR(2.0 * rel_coord / enbox_width_j);
+            if (rel_idx_dim_j[i] == 2) rel_idx_dim_j[i] = 1;
+            child_idx[i] += rel_idx_dim_j[i] * pow2;
+        }
+        pow2 *= 2;
+    }
+    
+    // 4. Get the number of points in each sub-box, then bucket sort all 
+    //    points according to the sub-box a point in
+    int *sub_rel_idx   = (int*) malloc(sizeof(int) * max_child * pt_dim);
+    int *sub_node_npts = (int*) malloc(sizeof(int) * max_child);
+    int *sub_displs    = (int*) malloc(sizeof(int) * (max_child + 1));
+    ASSERT_PRINTF(
+        sub_rel_idx != NULL && sub_node_npts != NULL && sub_displs != NULL,
+        "Failed to allocate working buffer of size %d for sub-nodes\n",
+        max_child * (pt_dim + 2)
+    );
+    memset(sub_node_npts, 0, sizeof(int) * max_child);
+    for (int i = 0; i < node_npts; i++)
+    {
+        int child_idx_i = child_idx[i];
+        sub_node_npts[child_idx_i]++;
+        for (int j = 0; j < pt_dim; j++)
+            sub_rel_idx[j * max_child + child_idx_i] = rel_idx[j * node_npts + i];
+    }
+    sub_displs[0] = 0;
+    for (int i = 1; i <= max_child; i++)
+        sub_displs[i] = sub_displs[i - 1] + sub_node_npts[i - 1];
+    // Notice: we need to copy both coordinates and extended information
+    for (int j = 0; j < xpt_dim; j++)
+    {
+        int dim_j_offset = j * n_point + coord_s;
+        DTYPE *src = coord     + dim_j_offset;
+        DTYPE *dst = coord_tmp + dim_j_offset;
+        memcpy(dst, src, sizeof(DTYPE) * node_npts);
+    }
+    memcpy(coord_idx_tmp + coord_s, coord_idx + coord_s, sizeof(int) * node_npts);
+    for (int i = 0; i < node_npts; i++)
+    {
+        int child_idx_i = child_idx[i];
+        int src_idx = coord_s + i;
+        int dst_idx = coord_s + sub_displs[child_idx_i];
+        DTYPE *coord_src = coord_tmp + src_idx;
+        DTYPE *coord_dst = coord     + dst_idx;
+        // Notice: we need to copy both coordinates and extended information
+        for (int j = 0; j < xpt_dim; j++)
+            coord_dst[j * n_point] = coord_src[j * n_point];
+        coord_idx[dst_idx] = coord_idx_tmp[src_idx];
+        sub_displs[child_idx_i]++;
+    }
+    
+    // 5. Prepare enclosing box data for each sub-box
+    int n_child = 0;
+    DTYPE *sub_box      = (DTYPE*) malloc(sizeof(DTYPE) * max_child * pt_dim * 2);
+    int   *sub_coord_se = (int*)   malloc(sizeof(int)   * max_child * 2);
+    ASSERT_PRINTF(
+        sub_box != NULL && sub_coord_se != NULL,
+        "Failed to allocate working buffer of size %d for sub-nodes\n",
+        max_child * (pt_dim + 1) * 2
+    );
+    sub_displs[0] = 0;
+    for (int i = 1; i <= max_child; i++)
+        sub_displs[i] = sub_displs[i - 1] + sub_node_npts[i - 1];
+    for (int i = 0; i < max_child; i++)
+    {
+        if (sub_node_npts[i] == 0) continue;
+        DTYPE *sub_box_child = sub_box + n_child * pt_dim * 2;
+        int *sub_rel_idx_i = sub_rel_idx + i;
+        for (int j = 0; j < pt_dim; j++)
+        {
+            sub_box_child[j] = enbox[j] + 0.5 * enbox[pt_dim + j] * sub_rel_idx_i[j * max_child] - 1e-12;
+            sub_box_child[pt_dim + j] = 0.5 * enbox[pt_dim + j] + 2e-12;
+        }
+        sub_coord_se[2 * n_child + 0] = coord_s + sub_displs[i];
+        sub_coord_se[2 * n_child + 1] = coord_s + sub_displs[i + 1] - 1;
+        n_child++;
+    }
+    
+    // 6. Recursively partition each sub-box
+    H2E_tree_node_p node;
+    H2E_tree_node_init(&node, pt_dim);
+    int n_node = 1, max_child_height = 0;
+    for (int i = 0; i < n_child; i++)
+    {
+        int coord_s_i = sub_coord_se[2 * i + 0];
+        int coord_e_i = sub_coord_se[2 * i + 1];
+        DTYPE *sub_box_i = sub_box + i * pt_dim * 2;
+        node->children[i] = H2E_bisection_partition_points(
+            level + 1, coord_s_i, coord_e_i, pt_dim, xpt_dim, n_point, 
+            max_leaf_size, max_leaf_points, sub_box_i, 
+            coord, coord_tmp, coord_idx, coord_idx_tmp, part_vars
+        );
+        H2E_tree_node_p child_node_i = (H2E_tree_node_p) node->children[i];
+        n_node += child_node_i->n_node;
+        max_child_height = MAX(max_child_height, child_node_i->height);
+    }
+    
+    // 7. Store information of this node
+    node->pt_cluster[0] = coord_s;
+    node->pt_cluster[1] = coord_e;
+    node->n_child = n_child;
+    node->n_node  = n_node;
+    node->po_idx  = part_vars->curr_po_idx;
+    node->level   = level;
+    node->height  = max_child_height + 1;
+    memcpy(node->enbox, enbox, sizeof(DTYPE) * pt_dim * 2);
+    part_vars->curr_po_idx++;
+
+    // 8. Free temporary arrays
+    free(sub_coord_se);
+    free(sub_box);
+    free(sub_displs);
+    free(sub_node_npts);
+    free(sub_rel_idx);
+    free(child_idx);
+    free(rel_idx);
+    if (alloc_enbox) free(enbox);
+    
+    return node;
+}
+
+// Convert a linked list H2 tree to arrays
+// Input parameter:
+//   node   : Current node of linked list H2 tree
+// Output parameter:
+//   h2eri : H2ERI structure with H2 tree partitioning in arrays
+void H2E_tree_to_array(H2E_tree_node_p node, H2ERI_p h2eri)
+{
+    int pt_dim    = h2eri->pt_dim;
+    int pt_dim2   = pt_dim * 2;
+    int max_child = 1 << pt_dim;
+    int node_idx  = node->po_idx;
+    int n_child   = node->n_child;
+    int level     = node->level;
+    int height    = node->height;
+    
+    // 1. Recursively convert sub-trees to arrays
+    for (int i = 0; i < node->n_child; i++)
+    {
+        H2E_tree_node_p child_i = (H2E_tree_node_p) node->children[i];
+        H2E_tree_to_array(child_i, h2eri);
+    }
+    
+    // 2. Copy information of current node to arrays
+    int *node_children = h2eri->children + node_idx * max_child;
+    for (int i = 0; i < n_child; i++)
+    {
+        H2E_tree_node_p child_i = (H2E_tree_node_p) node->children[i];
+        int child_idx = child_i->po_idx;
+        node_children[i] = child_idx;
+        h2eri->parent[child_idx] = node_idx;
+    }
+    for (int i = n_child; i < max_child; i++) node_children[i] = -1;
+    h2eri->pt_cluster[node_idx * 2 + 0] = node->pt_cluster[0];
+    h2eri->pt_cluster[node_idx * 2 + 1] = node->pt_cluster[1];
+    memcpy(h2eri->enbox + node_idx * pt_dim2, node->enbox, sizeof(DTYPE) * pt_dim2);
+    h2eri->node_level[node_idx]  = level;
+    h2eri->node_height[node_idx] = height;
+    h2eri->n_child[node_idx] = node->n_child;
+    int level_idx  = level  * h2eri->n_leaf_node + h2eri->level_n_node[level];
+    int height_idx = height * h2eri->n_leaf_node + h2eri->height_n_node[height];
+    h2eri->level_nodes[level_idx]   = node_idx;
+    h2eri->height_nodes[height_idx] = node_idx;
+    h2eri->level_n_node[level]++;
+    h2eri->height_n_node[height]++;
+}
+
+// Calculate reduced (in)admissible pairs of a H2 tree
+// Input parameters:
+//   h2eri     : H2ERI structure with H2 tree partitioning in arrays
+//   alpha     : Admissible pair coefficient
+//   n0, n1    : Node pair
+//   part_vars : Structure for storing working variables and arrays in point partitioning
+// Output parameter:
+//   h2eri : H2ERI structure reduced (in)admissible pairs
+void H2E_calc_reduced_adm_pairs(H2ERI_p h2eri, const DTYPE alpha, const int n0, const int n1, H2E_partition_vars_p part_vars)
+{
+    int   pt_dim        = h2eri->pt_dim;
+    int   max_child     = h2eri->max_child;
+    int   min_adm_level = h2eri->min_adm_level;
+    int   *children     = h2eri->children;
+    int   *n_child      = h2eri->n_child;
+    int   *node_level   = h2eri->node_level;
+    DTYPE *enbox        = h2eri->enbox;
+    
+    if (n0 == n1)
+    {
+        // Self box interaction
+        
+        // 1. Leaf node, nothing to do
+        int n_child_n0 = n_child[n0];
+        if (n_child_n0 == 0) return;
+        
+        // 2. Non-leaf node, check each children node
+        int *child_node = children + n0 * max_child;
+        // (1) Children node self box interaction
+        for (int i = 0; i < n_child_n0; i++)
+        {
+            int child_idx = child_node[i];
+            H2E_calc_reduced_adm_pairs(h2eri, alpha, child_idx, child_idx, part_vars);
+        }
+        // (2) Interaction between different children nodes
+        for (int i = 0; i < n_child_n0; i++)
+        {
+            int child_idx_i = child_node[i];
+            for (int j = i + 1; j < n_child_n0; j++)
+            {
+                int child_idx_j = child_node[j];
+                H2E_calc_reduced_adm_pairs(h2eri, alpha, child_idx_i, child_idx_j, part_vars);
+            }
+        }
+    } else {
+        // Interaction between two different nodes
+        int n_child_n0 = n_child[n0];
+        int n_child_n1 = n_child[n1];
+        int level_n0   = node_level[n0];
+        int level_n1   = node_level[n1];
+        
+        // 1. Admissible pair and the level of both node is larger than 
+        //    the minimum level of reduced admissible box pair 
+        DTYPE *enbox_n0 = enbox + n0 * pt_dim * 2;
+        DTYPE *enbox_n1 = enbox + n1 * pt_dim * 2;
+        if (H2E_check_box_admissible(enbox_n0, enbox_n1, pt_dim, alpha) &&
+            (level_n0 >= min_adm_level) && (level_n1 >= min_adm_level))
+        {
+            H2E_int_vec_push_back(part_vars->r_adm_pairs, n0);
+            H2E_int_vec_push_back(part_vars->r_adm_pairs, n1);
+            int max_level_n01 = MAX(level_n0, level_n1);
+            part_vars->min_adm_level = MIN(part_vars->min_adm_level, max_level_n01);
+            return;
+        }
+        
+        // 2. Two inadmissible leaf node
+        if ((n_child_n0 == 0) && (n_child_n1 == 0))
+        {
+            H2E_int_vec_push_back(part_vars->r_inadm_pairs, n0);
+            H2E_int_vec_push_back(part_vars->r_inadm_pairs, n1);
+            return;
+        }
+        
+        // 3. n0 is leaf node, n1 is non-leaf node: check n0 with n1's children
+        if ((n_child_n0 == 0) && (n_child_n1 > 0))
+        {
+            int *child_n1 = children + n1 * max_child;
+            for (int j = 0; j < n_child_n1; j++)
+            {
+                int n1_child_j = child_n1[j];
+                H2E_calc_reduced_adm_pairs(h2eri, alpha, n0, n1_child_j, part_vars);
+            }
+            return;
+        }
+        
+        // 4. n0 is non-leaf node, n1 is leaf node: check n1 with n0's children
+        if ((n_child_n0 > 0) && (n_child_n1 == 0))
+        {
+            int *child_n0 = children + n0 * max_child;
+            for (int i = 0; i < n_child_n0; i++)
+            {
+                int n0_child_i = child_n0[i];
+                H2E_calc_reduced_adm_pairs(h2eri, alpha, n0_child_i, n1, part_vars);
+            }
+            return;
+        }
+        
+        // 5. Neither n0 nor n1 is leaf node, check their children
+        if ((n_child_n0 > 0) && (n_child_n1 > 0))
+        {
+            int *child_n0 = children + n0 * max_child;
+            int *child_n1 = children + n1 * max_child;
+            for (int i = 0; i < n_child_n0; i++)
+            {
+                int n0_child_i = child_n0[i];
+                for (int j = 0; j < n_child_n1; j++)
+                {
+                    int n1_child_j = child_n1[j];
+                    H2E_calc_reduced_adm_pairs(h2eri, alpha, n0_child_i, n1_child_j, part_vars);
+                }
+            }
+        }
+    }  // End of "if (n0 == n1)"
+}
+
+// Partition points for a H2 tree
+void H2E_partition_points(
+    H2ERI_p h2eri, const int n_point, const DTYPE *coord, 
+    int max_leaf_points, DTYPE max_leaf_size
+)
+{
+    const int pt_dim  = h2eri->pt_dim;
+    const int xpt_dim = h2eri->xpt_dim;
+    double st, et;
+    
+    st = get_wtime_sec();
+
+    H2E_partition_vars_p part_vars;
+    H2E_partition_vars_init(&part_vars);
+    
+    // 1. Copy input point coordinates
+    h2eri->n_point = n_point;
+    if (max_leaf_points <= 0)
+    {
+        if (pt_dim == 2) max_leaf_points = 200;
+        else max_leaf_points = 400;
+    }
+    h2eri->max_leaf_points = max_leaf_points;
+    h2eri->max_leaf_size   = max_leaf_size;
+    h2eri->coord_idx       = (int*)   malloc(sizeof(int)   * n_point);
+    h2eri->coord           = (DTYPE*) malloc(sizeof(DTYPE) * n_point * xpt_dim);
+    h2eri->coord0          = (DTYPE*) malloc(sizeof(DTYPE) * n_point * xpt_dim);
+    ASSERT_PRINTF(
+        h2eri->coord != NULL && h2eri->coord0 != NULL && h2eri->coord_idx != NULL,
+        "Failed to allocate matrix of size %d * %d for storing point coordinates\n", xpt_dim, n_point
+    );
+    memcpy(h2eri->coord,  coord, sizeof(DTYPE) * n_point * xpt_dim);
+    memcpy(h2eri->coord0, coord, sizeof(DTYPE) * n_point * xpt_dim);
+    for (int i = 0; i < n_point; i++) h2eri->coord_idx[i] = i;
+    
+    // 2. Partition points for H2 tree using linked list 
+    int   *coord_idx_tmp = (int*)   malloc(sizeof(int)   * n_point);
+    DTYPE *coord_tmp     = (DTYPE*) malloc(sizeof(DTYPE) * n_point * xpt_dim);
+    ASSERT_PRINTF(
+        coord_tmp != NULL && coord_idx_tmp != NULL,
+        "Failed to allocate matrix of size %d * %d for temporarily storing point coordinates\n", 
+        pt_dim, n_point
+    );
+    H2E_tree_node_p root = H2E_bisection_partition_points(
+        0, 0, n_point-1, pt_dim, xpt_dim, n_point, 
+        max_leaf_size, max_leaf_points, h2eri->root_enbox, 
+        h2eri->coord, coord_tmp, h2eri->coord_idx, coord_idx_tmp, part_vars
+    );
+    free(coord_tmp);
+    free(coord_idx_tmp);
+    
+    // 3. Convert linked list H2 tree partition to arrays
+    int n_node    = root->n_node;
+    int max_child = 1 << pt_dim;
+    int max_level = part_vars->max_level;
+    h2eri->n_node        = n_node;
+    h2eri->root_idx      = n_node - 1;
+    h2eri->n_leaf_node   = part_vars->n_leaf_node;
+    h2eri->max_child     = max_child;
+    h2eri->max_level     = max_level++;
+    size_t int_n_node_msize    = sizeof(int)   * n_node;
+    size_t int_max_level_msize = sizeof(int)   * max_level;
+    size_t enbox_msize         = sizeof(DTYPE) * n_node * 2 * pt_dim;
+    h2eri->parent        = malloc(int_n_node_msize);
+    h2eri->children      = malloc(int_n_node_msize * max_child);
+    h2eri->pt_cluster    = malloc(int_n_node_msize * 2);
+    h2eri->mat_cluster   = malloc(int_n_node_msize * 2);
+    h2eri->n_child       = malloc(int_n_node_msize);
+    h2eri->node_level    = malloc(int_n_node_msize);
+    h2eri->node_height   = malloc(int_n_node_msize);
+    h2eri->level_n_node  = malloc(int_max_level_msize);
+    h2eri->level_nodes   = malloc(int_max_level_msize * h2eri->n_leaf_node);
+    h2eri->height_n_node = malloc(int_max_level_msize);
+    h2eri->height_nodes  = malloc(int_max_level_msize * h2eri->n_leaf_node);
+    h2eri->enbox         = malloc(enbox_msize);
+    ASSERT_PRINTF(h2eri->parent        != NULL, "Failed to allocate hierarchical partitioning tree arrays\n");
+    ASSERT_PRINTF(h2eri->children      != NULL, "Failed to allocate hierarchical partitioning tree arrays\n");
+    ASSERT_PRINTF(h2eri->pt_cluster    != NULL, "Failed to allocate hierarchical partitioning tree arrays\n");
+    ASSERT_PRINTF(h2eri->mat_cluster   != NULL, "Failed to allocate hierarchical partitioning tree arrays\n");
+    ASSERT_PRINTF(h2eri->n_child       != NULL, "Failed to allocate hierarchical partitioning tree arrays\n");
+    ASSERT_PRINTF(h2eri->node_level    != NULL, "Failed to allocate hierarchical partitioning tree arrays\n");
+    ASSERT_PRINTF(h2eri->node_height   != NULL, "Failed to allocate hierarchical partitioning tree arrays\n");
+    ASSERT_PRINTF(h2eri->level_n_node  != NULL, "Failed to allocate hierarchical partitioning tree arrays\n");
+    ASSERT_PRINTF(h2eri->level_nodes   != NULL, "Failed to allocate hierarchical partitioning tree arrays\n");
+    ASSERT_PRINTF(h2eri->height_n_node != NULL, "Failed to allocate hierarchical partitioning tree arrays\n");
+    ASSERT_PRINTF(h2eri->height_nodes  != NULL, "Failed to allocate hierarchical partitioning tree arrays\n");
+    ASSERT_PRINTF(h2eri->enbox         != NULL, "Failed to allocate hierarchical partitioning tree arrays\n");
+    memset(h2eri->level_n_node,  0, int_max_level_msize);
+    memset(h2eri->height_n_node, 0, int_max_level_msize);
+    H2E_tree_to_array(root, h2eri);
+    h2eri->parent[h2eri->root_idx] = -1;  // Root node doesn't have parent
+    H2E_tree_node_destroy(&root);  // We don't need the linked list H2 tree anymore
+    
+    // 4. Calculate reduced (in)admissible pairs
+    // h2eri->min_adm_level can be set manually to restrict the minimal admissible level
+    // If h2eri->min_adm_level != 0, part_vars->min_adm_level is useless
+    h2eri->min_adm_level = 0;
+    part_vars->min_adm_level = h2eri->max_level;
+    H2E_calc_reduced_adm_pairs(h2eri, ALPHA_H2, h2eri->root_idx, h2eri->root_idx, part_vars);
+    h2eri->min_adm_level = part_vars->min_adm_level;
+    
+    // 5. Copy reduced (in)admissible pairs from H2E_int_vec to h2eri arrays
+    h2eri->n_r_inadm_pair = part_vars->r_inadm_pairs->length / 2;
+    h2eri->n_r_adm_pair   = part_vars->r_adm_pairs->length   / 2;
+    size_t r_inadm_pairs_msize = sizeof(int) * h2eri->n_r_inadm_pair * 2;
+    size_t r_adm_pairs_msize   = sizeof(int) * h2eri->n_r_adm_pair   * 2;
+    h2eri->r_inadm_pairs = (int*) malloc(r_inadm_pairs_msize);
+    h2eri->r_adm_pairs   = (int*) malloc(r_adm_pairs_msize);
+    ASSERT_PRINTF(
+        h2eri->r_inadm_pairs != NULL && h2eri->r_adm_pairs != NULL,
+        "Failed to allocate arrays of sizes %d and %d for storing (in)admissible pairs\n",
+        h2eri->n_r_inadm_pair * 2, h2eri->n_r_adm_pair   * 2
+    );
+    memcpy(h2eri->r_inadm_pairs, part_vars->r_inadm_pairs->data, r_inadm_pairs_msize);
+    memcpy(h2eri->r_adm_pairs,   part_vars->r_adm_pairs->data,   r_adm_pairs_msize);
+
+    H2E_partition_vars_destroy(&part_vars);
+
+    et = get_wtime_sec();
+    h2eri->timers[PT_TIMER_IDX] = et - st;
+}

--- a/src/H2ERI_partition_points.h
+++ b/src/H2ERI_partition_points.h
@@ -1,0 +1,30 @@
+#ifndef __H2ERI_PARTITION_POINTS_H__
+#define __H2ERI_PARTITION_POINTS_H__
+
+#include "H2ERI_typedef.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Hierarchical point partitioning for H2 / HSS construction
+// Input parameters:
+//   h2eri           : H2ERI structure
+//   n_point         : Number of points for the kernel matrix
+//   coord           : Matrix, size h2eri->pt_dim * n_point, each column is a point coordinate
+//   max_leaf_points : Maximum point in a leaf node's box. If <= 0, will use 200 for
+//                     2D points and 400 for other dimensions
+//   max_leaf_size   : Maximum size of a leaf node's box. If == 0, max_leaf_points
+//                     will be the only restriction.
+// Output parameter:
+//   h2eri : H2ERI structure with point partitioning info
+void H2E_partition_points(
+    H2ERI_p h2eri, const int n_point, const DTYPE *coord, 
+    int max_leaf_points, DTYPE max_leaf_size
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/H2ERI_typedef.c
+++ b/src/H2ERI_typedef.c
@@ -2,11 +2,12 @@
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <omp.h>
 
 #include "CMS.h"
-#include "H2Pack_typedef.h"
 #include "H2ERI_typedef.h"
 #include "H2ERI_build_exchange.h"
+#include "H2ERI_aux_structs.h"
 
 // Initialize a H2ERI structure
 void H2ERI_init(H2ERI_p *h2eri_, const double scr_tol, const double ext_tol, const double QR_tol)
@@ -53,8 +54,25 @@ void H2ERI_init(H2ERI_p *h2eri_, const double scr_tol, const double ext_tol, con
     h2eri->c_B_blks              = NULL;
     h2eri->c_D_blks              = NULL;
     
-    double _QR_tol = QR_tol;
-    H2P_init(&h2eri->h2pack, 3, 1, QR_REL_NRM, &_QR_tol);
+    h2eri->n_thread = omp_get_max_threads();
+    h2eri->pt_dim    = 3;
+    h2eri->xpt_dim   = 3;
+    h2eri->krnl_dim  = 1;
+    h2eri->max_child = 1 << h2eri->pt_dim;
+    h2eri->max_neighbor = 1;
+    for (int i = 0; i < h2eri->pt_dim; i++) h2eri->max_neighbor *= 3;
+    h2eri->QR_stop_type = QR_REL_NRM;
+    memcpy(&h2eri->QR_stop_tol, &QR_tol, sizeof(DTYPE));
+
+    memset(h2eri->mat_size,  0, sizeof(size_t) * 11);
+    memset(h2eri->timers,    0, sizeof(double) * 11);
+    H2E_int_vec_init(&h2eri->B_blk,  h2eri->n_thread * BD_NTASK_THREAD + 5);
+    H2E_int_vec_init(&h2eri->D_blk0, h2eri->n_thread * BD_NTASK_THREAD + 5);
+    H2E_int_vec_init(&h2eri->D_blk1, h2eri->n_thread * BD_NTASK_THREAD + 5);
+    GET_ENV_INT_VAR(h2eri->print_timers,  "H2E_PRINT_TIMERS",  "print_timers",  0, 0, 1);
+    GET_ENV_INT_VAR(h2eri->print_dbginfo, "H2E_PRINT_DBGINFO", "print_dbginfo", 0, 0, 1);
+    if (h2eri->print_timers  == 1) INFO_PRINTF("H2ERI will print internal timers for performance analysis\n");
+    if (h2eri->print_dbginfo == 1) INFO_PRINTF("H2ERI will print debug information\n");
     
     *h2eri_ = h2eri;
 }
@@ -89,49 +107,206 @@ void H2ERI_destroy(H2ERI_p h2eri)
     free(h2eri->sp_shells);
     free(h2eri->sp);
     
-    for (int i = 0; i < h2eri->h2pack->n_node; i++)
+    for (int i = 0; i < h2eri->n_node; i++)
     {
-        H2P_int_vec_destroy(&h2eri->J_pair[i]);
-        H2P_int_vec_destroy(&h2eri->J_row[i]);
-        H2P_int_vec_destroy(&h2eri->ovlp_ff_idx[i]);
+        H2E_int_vec_destroy(&h2eri->J_pair[i]);
+        H2E_int_vec_destroy(&h2eri->J_row[i]);
+        H2E_int_vec_destroy(&h2eri->ovlp_ff_idx[i]);
     }
     free(h2eri->J_pair);
     free(h2eri->J_row);
     free(h2eri->ovlp_ff_idx);
     
-    for (int i = 0; i < h2eri->h2pack->n_thread; i++)
+    for (int i = 0; i < h2eri->n_thread; i++)
     {
         CMS_destroy_Simint_buff(h2eri->simint_buffs[i]);
         CMS_destroy_eri_batch_buff(h2eri->eri_batch_buffs[i]);
+        H2E_thread_buf_destroy(&h2eri->thread_buffs[i]);
     }
     free(h2eri->simint_buffs);
     free(h2eri->eri_batch_buffs);
+    free(h2eri->thread_buffs);
     
     if (h2eri->c_B_blks != NULL)
     {
-        H2P_dense_mat_p *c_B_blks = h2eri->c_B_blks;
-        for (int i = 0; i < h2eri->h2pack->n_B; i++)
-            H2P_dense_mat_destroy(&c_B_blks[i]);
+        H2E_dense_mat_p *c_B_blks = h2eri->c_B_blks;
+        for (int i = 0; i < h2eri->n_B; i++)
+            H2E_dense_mat_destroy(&c_B_blks[i]);
         free(c_B_blks);
     }
     
     if (h2eri->c_D_blks != NULL)
     {
-        H2P_dense_mat_p *c_D_blks = h2eri->c_D_blks;
-        for (int i = 0; i < h2eri->h2pack->n_D; i++)
-            H2P_dense_mat_destroy(&c_D_blks[i]);
+        H2E_dense_mat_p *c_D_blks = h2eri->c_D_blks;
+        for (int i = 0; i < h2eri->n_D; i++)
+            H2E_dense_mat_destroy(&c_D_blks[i]);
         free(c_D_blks);
     }
-    
-    H2P_destroy(&h2eri->h2pack);
 }
 
 // Print H2ERI statistic information
 void H2ERI_print_statistic(H2ERI_p h2eri)
 {
+    if (h2eri == NULL) return;
+    if (h2eri->n_node == 0)
+    {
+        printf("H2ERI has nothing to report yet.\n");
+        return;
+    }
+
     printf("================ H2ERI molecular system info ================\n");
     printf("  * Number of atoms / shells / basis functions : %d, %d, %d\n", h2eri->natom, h2eri->nshell, h2eri->num_bf);
     printf("  * Number of symm-unique screened shell pairs : %d\n", h2eri->num_sp);
+    printf("==================== H2ERI H2 tree info ====================\n");
+    printf("  * Number of points               : %d\n", h2eri->n_point);
+    printf("  * Kernel matrix size             : %d\n", h2eri->krnl_mat_size);
+    printf("  * Maximum points in a leaf node  : %d\n", h2eri->max_leaf_points);
+    printf("  * Maximum leaf node box size     : %e\n", h2eri->max_leaf_size);
+    printf("  * Number of levels (root at 0)   : %d\n", h2eri->max_level+1);
+    printf("  * Number of nodes                : %d\n", h2eri->n_node);
+    printf("  * Number of nodes on each level  : ");
+    for (int i = 0; i < h2eri->max_level; i++) 
+        printf("%d, ", h2eri->level_n_node[i]);
+    printf("%d\n", h2eri->level_n_node[h2eri->max_level]);
+    printf("  * Number of nodes on each height : ");
+    for (int i = 0; i < h2eri->max_level; i++) 
+        printf("%d, ", h2eri->height_n_node[i]);
+    printf("%d\n", h2eri->height_n_node[h2eri->max_level]);
+    printf("  * Minimum admissible pair level  : %d\n", h2eri->min_adm_level);
+    printf("  * Number of reduced adm. pairs   : %d\n", h2eri->n_r_adm_pair);
+    printf("  * Number of reduced inadm. pairs : %d\n", h2eri->n_r_inadm_pair);
     
-    H2P_print_statistic(h2eri->h2pack);
+    if (h2eri->U == NULL) 
+    {
+        printf("H2ERI H2 matrix has not been constructed yet.\n");
+        return;
+    }
+    
+    printf("==================== H2ERI storage info ====================\n");
+    size_t *mat_size = h2eri->mat_size;
+    double DTYPE_MB = (double) sizeof(DTYPE) / 1048576.0;
+    double int_MB   = (double) sizeof(int)   / 1048576.0;
+    double U_MB   = (double) mat_size[U_SIZE_IDX]      * DTYPE_MB;
+    double B_MB   = (double) mat_size[B_SIZE_IDX]      * DTYPE_MB;
+    double D_MB   = (double) mat_size[D_SIZE_IDX]      * DTYPE_MB;
+    double fwd_MB = (double) mat_size[MV_FWD_SIZE_IDX] * DTYPE_MB;
+    double mid_MB = (double) mat_size[MV_MID_SIZE_IDX] * DTYPE_MB;
+    double bwd_MB = (double) mat_size[MV_BWD_SIZE_IDX] * DTYPE_MB;
+    double den_MB = (double) mat_size[MV_DEN_SIZE_IDX] * DTYPE_MB;
+    double vop_MB = (double) mat_size[MV_VOP_SIZE_IDX] * DTYPE_MB;
+    double mv_MB  = fwd_MB + mid_MB + bwd_MB + den_MB;
+    double UBD_k  = 0.0;
+    UBD_k += (double) mat_size[U_SIZE_IDX];
+    UBD_k += (double) mat_size[B_SIZE_IDX];
+    UBD_k += (double) mat_size[D_SIZE_IDX];
+    UBD_k /= (double) h2eri->krnl_mat_size;
+    double matvec_MB = 0.0;
+    for (int i = 0; i < h2eri->n_thread; i++)
+    {
+        H2E_thread_buf_p tbi = h2eri->thread_buffs[i];
+        double msize0 = (double) tbi->mat0->size     + (double) tbi->mat1->size;
+        double msize1 = (double) tbi->idx0->capacity + (double) tbi->idx1->capacity;
+        matvec_MB += DTYPE_MB * msize0 + int_MB * msize1;
+        matvec_MB += DTYPE_MB * (double) h2eri->krnl_mat_size;
+    }
+    if (h2eri->y0 != NULL && h2eri->y1 != NULL)
+    {
+        for (int i = 0; i < h2eri->n_node; i++)
+        {
+            H2E_dense_mat_p y0i = h2eri->y0[i];
+            H2E_dense_mat_p y1i = h2eri->y1[i];
+            matvec_MB += DTYPE_MB * (y0i->size + y1i->size);
+        }
+    }
+    printf("  * Just-In-Time B & D build      : %s\n", h2eri->BD_JIT ? "Yes (B & D not allocated)" : "No");
+    printf("  * H2 representation U, B, D     : %.2lf, %.2lf, %.2lf (MB) \n", U_MB, B_MB, D_MB);
+    printf("  * Matvec auxiliary arrays       : %.2lf (MB) \n", matvec_MB);
+    int max_node_rank = 0;
+    double sum_node_rank = 0.0, non_empty_node = 0.0;
+    for (int i = 0; i < h2eri->n_UJ; i++)
+    {
+        int rank_i = h2eri->U[i]->ncol;
+        if (rank_i > 0)
+        {
+            sum_node_rank  += (double) rank_i;
+            non_empty_node += 1.0;
+            max_node_rank   = (rank_i > max_node_rank) ? rank_i : max_node_rank;
+        }
+    }
+    printf("  * Max / Avg compressed rank     : %d, %.0lf \n", max_node_rank, sum_node_rank / non_empty_node);
+    
+    printf("==================== H2ERI timing info =====================\n");
+    double *timers = h2eri->timers;
+    double build_t = 0.0, matvec_t = 0.0;
+    double d_n_matvec = (double) h2eri->n_matvec;
+    build_t += timers[PT_TIMER_IDX];
+    build_t += timers[U_BUILD_TIMER_IDX];
+    build_t += timers[B_BUILD_TIMER_IDX];
+    build_t += timers[D_BUILD_TIMER_IDX];
+    printf("  * H2 construction time (sec)   = %.3lf \n", build_t);
+    printf("      |----> Point partition     = %.3lf \n", timers[PT_TIMER_IDX]);
+    printf("      |----> U construction      = %.3lf \n", timers[U_BUILD_TIMER_IDX]);
+    printf("      |----> B construction      = %.3lf \n", timers[B_BUILD_TIMER_IDX]);
+    printf("      |----> D construction      = %.3lf \n", timers[D_BUILD_TIMER_IDX]);
+
+    if (h2eri->n_matvec == 0)
+    {
+        printf("H2ERI does not have matvec timings results yet.\n");
+    } else {
+        double fwd_t = timers[MV_FWD_TIMER_IDX] / d_n_matvec;
+        double mid_t = timers[MV_MID_TIMER_IDX] / d_n_matvec;
+        double bwd_t = timers[MV_BWD_TIMER_IDX] / d_n_matvec;
+        double den_t = timers[MV_DEN_TIMER_IDX] / d_n_matvec;
+        double vop_t = timers[MV_VOP_TIMER_IDX] / d_n_matvec;
+        matvec_t = fwd_t + mid_t + bwd_t + den_t + vop_t;
+        printf(
+            "  * H2 matvec average time (sec) = %.3lf, %.2lf GB/s\n", 
+            matvec_t, mv_MB / matvec_t / 1024.0
+        );
+        printf(
+            "      |----> Forward transformation      = %.3lf, %.2lf GB/s\n", 
+            fwd_t, fwd_MB / fwd_t / 1024.0
+        );
+        if (h2eri->BD_JIT == 0)
+        {
+            printf(
+                "      |----> Intermediate multiplication = %.3lf, %.2lf GB/s\n", 
+                mid_t, mid_MB / mid_t / 1024.0
+            );
+        } else {
+            printf("      |----> Intermediate multiplication = %.3lf\n", mid_t);
+        }
+        printf(
+            "      |----> Backward transformation     = %.3lf, %.2lf GB/s\n", 
+            bwd_t, bwd_MB / bwd_t / 1024.0
+        );
+        if (h2eri->BD_JIT == 0)
+        {
+            printf(
+                "      |----> Dense multiplication        = %.3lf, %.2lf GB/s\n", 
+                den_t, den_MB / den_t / 1024.0
+            );
+        } else {
+            printf("      |----> Dense multiplication        = %.3lf GFLOPS\n", den_t);
+        }
+        vop_MB /= d_n_matvec;
+        printf(
+            "      |----> OpenMP vector operations    = %.3lf, %.2lf GB/s\n", 
+            vop_t, vop_MB / vop_t / 1024.0
+        );
+    }
+    
+    printf("=============================================================\n");
+}
+
+// Reset timing statistical info of an H2ERI structure
+void H2E_reset_timers(H2ERI_p h2eri)
+{
+    h2eri->n_matvec = 0;
+    h2eri->mat_size[MV_VOP_SIZE_IDX] = 0;
+    h2eri->timers[MV_FWD_TIMER_IDX]  = 0.0;
+    h2eri->timers[MV_MID_TIMER_IDX]  = 0.0;
+    h2eri->timers[MV_BWD_TIMER_IDX]  = 0.0;
+    h2eri->timers[MV_DEN_TIMER_IDX]  = 0.0;
+    h2eri->timers[MV_VOP_TIMER_IDX]  = 0.0;
 }

--- a/src/H2ERI_typedef.h
+++ b/src/H2ERI_typedef.h
@@ -4,9 +4,8 @@
 // Shell operations used in H2P-ERI
 
 #include "CMS.h"
-#include "H2Pack_config.h"
-#include "H2Pack_typedef.h"
-#include "H2Pack_aux_structs.h"
+#include "H2ERI_config.h"
+#include "H2ERI_aux_structs.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -28,37 +27,135 @@ struct H2ERI
     int    *sp_bfp_sidx;                // Array, size num_sp+1, indices of each SSP's first basis function pair
     int    *sp_shell_idx;               // Array, size 2 * num_sp, each row is the contracted shell indices of a SSP
     int    *index_seq;                  // Array, size num_sp, [0, num_sp-1]
-    int    *node_adm_pairs;             // Array, size 2 * h2pack->n_r_adm_pair, each node's admissible node pairs
-    int    *node_adm_pairs_sidx;        // Array, size h2pack->n_node+1, index of each node's first admissible node pair
-    int    *node_inadm_pairs;           // Array, size 2 * h2pack->n_r_inadm_pair, each node's inadmissible node pairs
-    int    *node_inadm_pairs_sidx;      // Array, size h2pack->n_node+1, index of each node's first inadmissible node pair
+    int    *node_adm_pairs;             // Array, size 2 * h2eri->n_r_adm_pair, each node's admissible node pairs
+    int    *node_adm_pairs_sidx;        // Array, size h2eri->n_node+1, index of each node's first admissible node pair
+    int    *node_inadm_pairs;           // Array, size 2 * h2eri->n_r_inadm_pair, each node's inadmissible node pairs
+    int    *node_inadm_pairs_sidx;      // Array, size h2eri->n_node+1, index of each node's first inadmissible node pair
     int    *plist;                      // Array, size <= 2*num_sp, each shell's screened pair shells
     int    *plist_idx;                  // Array, size <= 2*num_sp, corresponding indices of each shell's screened pair shells in sp_bfp_sidx
     int    *plist_sidx;                 // Array, size nshell+1, index of each node's first item in plist & plist_idx
     int    *dlist;                      // Array, size unknown, each shell's pair shells s.t. the corresponding density matrix block is large enough
     int    *dlist_sidx;                 // Array, size nshell+1, index of each node's first item in dlist
-    void   **thread_Kmat_workbuf;       // Array, size h2pack->n_thread, pointers to each thread's K mat build work buffer
+    void   **thread_Kmat_workbuf;       // Array, size h2eri->n_thread, pointers to each thread's K mat build work buffer
     double scr_tol;                     // Tolerance of Schwarz screening
     double ext_tol;                     // Tolerance of shell pair extent
     double *sp_center;                  // Array, size 3 * num_sp, each column is a SSP's center
     double *sp_extent;                  // Array, size num_sp, extents of SSP
-    double *box_extent;                 // Array, size h2pack->n_node, extents of each H2 node box
+    double *box_extent;                 // Array, size h2eri->n_node, extents of each H2 node box
     double *unc_denmat_x;               // Array, size num_sp_bfp, uncontracted density matrix as a vector
     double *H2_matvec_y;                // Array, size num_sp_bfp, H2 matvec result 
     shell_t          *shells;           // Array, size nshell, contracted shells
     shell_t          *sp_shells;        // Array, size 2 * num_sp, each column is a SSP
     multi_sp_t       *sp;               // Array, size num_sp, SSP
-    H2P_int_vec_p    *J_pair;           // Array, size h2pack->n_node, skeleton shell pair indices of each node
-    H2P_int_vec_p    *J_row;            // Array, size h2pack->n_node, skeleton row indices in each node's shell pairs
-    H2P_int_vec_p    *ovlp_ff_idx;      // Array, size h2pack->n_node, i-th vector contains the far field points whose extents are overlapped with the near field of i-th node
-    simint_buff_p    *simint_buffs;     // Array, size h2pack->n_thread, simint_buff structures for each thread
-    eri_batch_buff_p *eri_batch_buffs;  // Array, size h2pack->n_thread, eri_batch_buff structures for each thread
-    H2P_dense_mat_p  *c_B_blks;         // Array, size h2pack->n_B, compressed B blocks
-    H2P_dense_mat_p  *c_D_blks;         // Array, size h2pack->n_D, compressed D blocks
-    H2Pack_p         h2pack;            // H2Pack data structure
-};
+    H2E_int_vec_p    *J_pair;           // Array, size h2eri->n_node, skeleton shell pair indices of each node
+    H2E_int_vec_p    *J_row;            // Array, size h2eri->n_node, skeleton row indices in each node's shell pairs
+    H2E_int_vec_p    *ovlp_ff_idx;      // Array, size h2eri->n_node, i-th vector contains the far field points whose extents are overlapped with the near field of i-th node
+    simint_buff_p    *simint_buffs;     // Array, size h2eri->n_thread, simint_buff structures for each thread
+    eri_batch_buff_p *eri_batch_buffs;  // Array, size h2eri->n_thread, eri_batch_buff structures for each thread
+    H2E_dense_mat_p  *c_B_blks;         // Array, size h2eri->n_B, compressed B blocks
+    H2E_dense_mat_p  *c_D_blks;         // Array, size h2eri->n_D, compressed D blocks
+    H2E_thread_buf_p *thread_buffs;     // Array, size n_thread, thread buffers for each thread
 
+    // Variables originally from H2Pack
+    int    n_thread;                // Number of threads
+    int    pt_dim;                  // Dimension of point coordinate
+    int    xpt_dim;                 // Dimension of extended point coordinate (for RPY)
+    int    krnl_dim;                // Dimension of tensor kernel's return
+    int    QR_stop_type;            // Partial QR stop criteria
+    int    QR_stop_rank;            // Partial QR maximum rank
+    int    n_point;                 // Number of points for the kernel matrix
+    int    krnl_mat_size;           // Size of the kernel matrix
+    int    max_leaf_points;         // Maximum point in a leaf node's box
+    int    n_node;                  // Number of nodes in this H2 tree
+    int    root_idx;                // Index of the root node (== n_node - 1, save it for convenience)
+    int    n_leaf_node;             // Number of leaf nodes in this H2 tree
+    int    max_child;               // Maximum number of children per node, == 2^pt_dim
+    int    max_neighbor;            // Maximum number of neighbor nodes per node, == 2^pt_dim
+    int    max_level;               // Maximum level of this H2 tree, (root = 0, total max_level + 1 levels)
+    int    min_adm_level;           // Minimum level of reduced admissible pair
+    int    n_r_inadm_pair;          // Number of reduced inadmissible pairs
+    int    n_r_adm_pair;            // Number of reduced admissible pairs
+    int    n_UJ;                    // Number of projection matrices & skeleton row sets, == n_node
+    int    n_B;                     // Number of generator matrices
+    int    n_D;                     // Number of dense blocks
+    int    BD_JIT;                  // If B and D matrices are computed just-in-time in matvec
+    int    print_timers;            // If H2ERI prints internal timers for performance analysis
+    int    print_dbginfo;           // If H2ERI prints debug information
+    int    *parent;                 // Size n_node, parent index of each node
+    int    *children;               // Size n_node * max_child, indices of a node's children nodes
+    int    *pt_cluster;             // Size n_node * 2, start and end (included) indices of points belong to each node
+    int    *mat_cluster;            // Size n_node * 2, start and end (included) indices of matvec vector elements belong to each node
+    int    *n_child;                // Size n_node, number of children nodes of each node
+    int    *node_level;             // Size n_node, level of each node
+    int    *node_height;            // Size n_node, height of each node
+    int    *level_n_node;           // Size max_level+1, number of nodes in each level
+    int    *level_nodes;            // Size (max_level+1) * n_leaf_node, indices of nodes on each level
+    int    *height_n_node;          // Size max_level+1, number of nodes of each height
+    int    *height_nodes;           // Size (max_level+1) * n_leaf_node, indices of nodes of each height
+    int    *r_inadm_pairs;          // Size unknown, reduced inadmissible pairs 
+    int    *r_adm_pairs;            // Size unknown, reduced admissible pairs 
+    int    *node_inadm_lists;       // Size n_node * max_neighbor, lists of each node's inadmissible nodes
+    int    *node_n_r_inadm;         // Size n_node, numbers of each node's reduced inadmissible nodes
+    int    *node_n_r_adm;           // Size n_node, numbers of each node's reduced admissible nodes
+    int    *coord_idx;              // Size n_point, original index of each sorted point
+    int    *B_p2i_rowptr;           // Size n_node+1, row_ptr array of the CSR matrix for mapping B{i, j} to a B block index
+    int    *B_p2i_colidx;           // Size n_B, col_idx array of the CSR matrix for mapping B{i, j} to a B block index
+    int    *B_p2i_val;              // Size n_B, val array of the CSR matrix for mapping B{i, j} to a B block index
+    int    *D_p2i_rowptr;           // Size n_node+1, row_ptr array of the CSR matrix for mapping D{i, j} to a D block index
+    int    *D_p2i_colidx;           // Size n_D, col_idx array of the CSR matrix for mapping D{i, j} to a D block index
+    int    *D_p2i_val;              // Size n_D, val array of the CSR matrix for mapping D{i, j} to a D block index
+    int    *B_nrow;                 // Size n_B, numbers of rows of generator matrices
+    int    *B_ncol;                 // Size n_B, numbers of columns of generator matrices
+    int    *D_nrow;                 // Size n_D, numbers of rows of dense blocks in the original matrix
+    int    *D_ncol;                 // Size n_D, numbers of columns of dense blocks in the original matrix
+    size_t *B_ptr;                  // Size n_B, offset of each generator matrix's data in B_data
+    size_t *D_ptr;                  // Size n_D, offset of each dense block's data in D_data
+    DTYPE  max_leaf_size;           // Maximum size of a leaf node's box
+    DTYPE  QR_stop_tol;             // Partial QR stop column norm tolerance
+    DTYPE  *coord;                  // Size n_point * xpt_dim, sorted point coordinates
+    DTYPE  *coord0;                 // Size n_point * xpt_dim, original (not sorted) point coordinates
+    DTYPE  *enbox;                  // Size n_node * (2*pt_dim), enclosing box data of each node
+    DTYPE  *root_enbox;             // Size 2 * pt_dim, enclosing box of the root node
+    DTYPE  *B_data;                 // Size unknown, data of generator matrices
+    DTYPE  *D_data;                 // Size unknown, data of dense blocks in the original matrix
+    H2E_int_vec_p     B_blk;        // Size BD_NTASK_THREAD * n_thread, B matrices task partitioning
+    H2E_int_vec_p     D_blk0;       // Size BD_NTASK_THREAD * n_thread, diagonal blocks in D matrices task partitioning
+    H2E_int_vec_p     D_blk1;       // Size BD_NTASK_THREAD * n_thread, inadmissible blocks in D matrices task partitioning
+    H2E_dense_mat_p   *U;           // Size n_node, Projection matrices
+    H2E_dense_mat_p   *y0;          // Size n_node, temporary arrays used in matvec
+    H2E_dense_mat_p   *y1;          // Size n_node, temporary arrays used in matvec
+    int    n_matvec;                // Number of performed matvec
+    size_t mat_size[11];            // See below macros
+    double timers[11];              // See below macros
+};
 typedef struct H2ERI* H2ERI_p;
+
+// For H2ERI_t->mat_size
+typedef enum 
+{
+    U_SIZE_IDX = 0,     // Total size of U matrices
+    B_SIZE_IDX,         // Total size of B matrices
+    D_SIZE_IDX,         // Total size of D matrices
+    MV_FWD_SIZE_IDX,    // Total memory footprint of H2 matvec forward transformation
+    MV_MID_SIZE_IDX,    // Total memory footprint of H2 matvec intermediate multiplication
+    MV_BWD_SIZE_IDX,    // Total memory footprint of H2 matvec backward transformation
+    MV_DEN_SIZE_IDX,    // Total memory footprint of H2 matvec dense multiplication
+    MV_VOP_SIZE_IDX,    // Total memory footprint of H2 matvec OpenMP vector operations
+} size_idx_t;
+
+// For H2ERI_t->timers
+typedef enum
+{
+    PT_TIMER_IDX = 0,   // Hierarchical partitioning
+    U_BUILD_TIMER_IDX,  // U matrices construction
+    B_BUILD_TIMER_IDX,  // B matrices construction
+    D_BUILD_TIMER_IDX,  // D matrices construction
+    MV_FWD_TIMER_IDX,   // H2 matvec forward transformation
+    MV_MID_TIMER_IDX,   // H2 matvec intermediate multiplication
+    MV_BWD_TIMER_IDX,   // H2 matvec backward transformation
+    MV_DEN_TIMER_IDX,   // H2 matvec dense multiplication
+    MV_VOP_TIMER_IDX,   // H2 matvec OpenMP vector operations
+} timer_idx_t;
 
 #define ALPHA_SUP 1.0
 

--- a/src/H2ERI_utils.c
+++ b/src/H2ERI_utils.c
@@ -4,7 +4,193 @@
 #include <assert.h>
 #include <math.h>
 
-#include "H2ERI_typedef.h"
 #include "H2ERI_utils.h"
+#include "H2ERI_aux_structs.h"
 
-// Nothing here yet
+// Check if two boxes are admissible 
+int H2E_check_box_admissible(const DTYPE *box0, const DTYPE *box1, const int pt_dim, const DTYPE alpha)
+{
+    for (int i = 0; i < pt_dim; i++)
+    {
+        // Radius of each box's i-th dimension
+        DTYPE r0 = box0[pt_dim + i];
+        DTYPE r1 = box1[pt_dim + i];
+        // Center of each box's i-th dimension
+        DTYPE c0 = box0[i] + 0.5 * r0;
+        DTYPE c1 = box1[i] + 0.5 * r1;
+        DTYPE min_r = MIN(r0, r1);
+        DTYPE dist  = DABS(c0 - c1);
+        if (dist >= alpha * min_r + 0.5 * (r0 + r1)) return 1;
+    }
+    return 0;
+}
+
+// Quick sorting an integer key-value pair array by key in ascending order
+void H2E_qsort_int_kv_ascend(int *key, int *val, int l, int r)
+{
+    int i = l, j = r, tmp_key, tmp_val;
+    int mid_key = key[(l + r) / 2];
+    while (i <= j)
+    {
+        while (key[i] < mid_key) i++;
+        while (key[j] > mid_key) j--;
+        if (i <= j)
+        {
+            tmp_key = key[i]; key[i] = key[j]; key[j] = tmp_key;
+            tmp_val = val[i]; val[i] = val[j]; val[j] = tmp_val;
+            i++;  j--;
+        }
+    }
+    if (i < r) H2E_qsort_int_kv_ascend(key, val, i, r);
+    if (j > l) H2E_qsort_int_kv_ascend(key, val, l, j);
+}
+
+// Generate a random sparse matrix A for calculating y^T := A^T * x^T
+void H2E_gen_rand_sparse_mat_trans(
+    const int max_nnz_col, const int k, const int n, 
+    H2E_dense_mat_p A_valbuf, H2E_int_vec_p A_idxbuf
+)
+{
+    // Note: we calculate y^T := A^T * x^T. Since x/y is row-major, 
+    // each of its row is a column of x^T/y^T. We can just use SpMV
+    // to calculate y^T(:, i) := A^T * x^T(:, i). 
+
+    int rand_nnz_col = (max_nnz_col <= k) ? max_nnz_col : k;
+    int nnz = n * rand_nnz_col;
+    H2E_dense_mat_resize(A_valbuf, 1, nnz);
+    H2E_int_vec_set_capacity(A_idxbuf, (n + 1) + nnz + k);
+    DTYPE *val = A_valbuf->data;
+    int *row_ptr = A_idxbuf->data;
+    int *col_idx = row_ptr + (n + 1);
+    int *flag = col_idx + nnz; 
+    memset(flag, 0, sizeof(int) * k);
+    for (int i = 0; i < nnz; i++) 
+        val[i] = (DTYPE) (2.0 * (rand() & 1) - 1.0);
+    for (int i = 0; i <= n; i++) 
+        row_ptr[i] = i * rand_nnz_col;
+    for (int i = 0; i < n; i++)
+    {
+        int cnt = 0;
+        int *row_i_cols = col_idx + i * rand_nnz_col;
+        while (cnt < rand_nnz_col)
+        {
+            int col = rand() % k;
+            if (flag[col] == 0) 
+            {
+                flag[col] = 1;
+                row_i_cols[cnt] = col;
+                cnt++;
+            }
+        }
+        for (int j = 0; j < rand_nnz_col; j++)
+            flag[row_i_cols[j]] = 0;
+    }
+    A_idxbuf->length = (n + 1) + nnz;
+}
+
+// Calculate y^T := A^T * x^T, where A is a sparse matrix, x and y are row-major matrices
+void H2E_calc_sparse_mm_trans(
+    const int m, const int n, const int k,
+    H2E_dense_mat_p A_valbuf, H2E_int_vec_p A_idxbuf,
+    DTYPE *x, const int ldx, DTYPE *y, const int ldy
+)
+{
+    const DTYPE *val = A_valbuf->data;
+    const int *row_ptr = A_idxbuf->data;
+    const int *col_idx = row_ptr + (n + 1);  // A is k-by-n
+    // Doing a naive OpenMP CSR SpMM here is good enough, using MKL SpBLAS is actually
+    // slower, probably due to the cost of optimizing the storage of sparse matrix
+    #pragma omp parallel for schedule(static)
+    for (int i = 0; i < m; i++)
+    {
+        DTYPE *x_i = x + i * ldx;
+        DTYPE *y_i = y + i * ldy;
+        
+        for (int j = 0; j < n; j++)
+        {
+            DTYPE res = 0.0;
+            #pragma omp simd
+            for (int l = row_ptr[j]; l < row_ptr[j+1]; l++)
+                res += val[l] * x_i[col_idx[l]];
+            y_i[j] = res;
+        }
+    }
+}
+
+// Convert a integer COO matrix to a CSR matrix 
+void H2E_int_COO_to_CSR(
+    const int nrow, const int nnz, const int *row, const int *col, 
+    const int *val, int *row_ptr, int *col_idx, int *val_
+)
+{
+    // Get the number of non-zeros in each row
+    memset(row_ptr, 0, sizeof(int) * (nrow + 1));
+    for (int i = 0; i < nnz; i++) row_ptr[row[i] + 1]++;
+    // Calculate the displacement of 1st non-zero in each row
+    for (int i = 2; i <= nrow; i++) row_ptr[i] += row_ptr[i - 1];
+    // Use row_ptr to bucket sort col[] and val[]
+    for (int i = 0; i < nnz; i++)
+    {
+        int idx = row_ptr[row[i]];
+        col_idx[idx] = col[i];
+        val_[idx] = val[i];
+        row_ptr[row[i]]++;
+    }
+    // Reset row_ptr
+    for (int i = nrow; i >= 1; i--) row_ptr[i] = row_ptr[i - 1];
+    row_ptr[0] = 0;
+    // Sort the non-zeros in each row according to column indices
+    #pragma omp parallel for
+    for (int i = 0; i < nrow; i++)
+        H2E_qsort_int_kv_ascend(col_idx, val_, row_ptr[i], row_ptr[i + 1] - 1);
+}
+
+// Get the value of integer CSR matrix element A(row, col)
+int H2E_get_int_CSR_elem(
+    const int *row_ptr, const int *col_idx, const int *val,
+    const int row, const int col
+)
+{
+    int res = 0;
+    for (int i = row_ptr[row]; i < row_ptr[row + 1]; i++)
+    {
+        if (col_idx[i] == col) 
+        {
+            res = val[i];
+            break;
+        }
+    }
+    return res;
+}
+
+// Partition work units into multiple blocks s.t. each block has 
+// approximately the same amount of work
+void H2E_partition_workload(
+    const int n_work,  const size_t *work_sizes, const size_t total_size, 
+    const int n_block, H2E_int_vec_p blk_displs
+)
+{
+    H2E_int_vec_set_capacity(blk_displs, n_block + 1);
+    blk_displs->data[0] = 0;
+    for (int i = 1; i < blk_displs->capacity; i++) 
+        blk_displs->data[i] = n_work;
+    size_t blk_size = total_size / n_block + 1;
+    size_t curr_blk_size = 0;
+    int idx = 1;
+    for (int i = 0; i < n_work; i++)
+    {
+        curr_blk_size += work_sizes[i];
+        if (curr_blk_size >= blk_size)
+        {
+            blk_displs->data[idx] = i + 1;
+            curr_blk_size = 0;
+            idx++;
+        }
+    }
+    if (curr_blk_size > 0)
+    {
+        blk_displs->data[idx] = n_work;
+        idx++;
+    }
+    blk_displs->length = idx;
+}

--- a/src/H2ERI_utils.h
+++ b/src/H2ERI_utils.h
@@ -2,6 +2,12 @@
 #define __H2ERI_UTILS_H__
 
 #include "H2ERI_typedef.h"
+#include "H2ERI_config.h"
+#include "H2ERI_aux_structs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 static inline void atomic_add_f64(volatile double *global_addr, double addend)
 {
@@ -27,9 +33,97 @@ static inline int H2ERI_gather_sum_int(const int *arr, const int nelem, const in
     return res;
 }
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+// Check if two boxes are admissible 
+// Input parameters:
+//   box0, box1 : Box data, [0 : pt_dim-1] are coordinates of the box corner which is 
+//                closest to the original point, [pt_dim : 2*pt_dim-1] are box length
+//   pt_dim     : Dimension of point coordinate
+//   alpha      : Admissible pair coefficient
+// Output parameter:
+//   <return>   : If two boxes are admissible 
+int H2E_check_box_admissible(const DTYPE *box0, const DTYPE *box1, const int pt_dim, const DTYPE alpha);
+
+// Quick sorting an integer key-value pair array by key in ascending order
+void H2E_qsort_int_kv_ascend(int *key, int *val, int l, int r);
+
+// Generate a random sparse matrix A for calculating y^T := A^T * x^T,
+// where A is a random sparse matrix that has no more than max_nnz_col 
+// random +1/-1 nonzeros in each column with random position, x and y 
+// are row-major matrices. Each row of x/y is a column of x^T/y^T. We 
+// can just use SpMV to calculate y^T(:, i) := A^T * x^T(:, i).
+// Input parameters:
+//   max_nnz_col : Maximum number of nonzeros in each column of A
+//   k, n        : A is k-by-n sparse matrix
+// Output parameters:
+//   A_valbuf : Buffer for storing nonzeros of A^T
+//   A_idxbuf : Buffer for storing CSR row_ptr and col_idx arrays of A^T. 
+//              A_idxbuf->data[0 : n] stores row_ptr, A_idxbuf->data[n+1 : end]
+//              stores col_idx.
+void H2E_gen_rand_sparse_mat_trans(
+    const int max_nnz_col, const int k, const int n, 
+    H2E_dense_mat_p A_valbuf, H2E_int_vec_p A_idxbuf
+);
+
+// Calculate y^T := A^T * x^T, where A is a sparse matrix, 
+// x and y are row-major matrices. Since x/y is row-major, 
+// each of its row is a column of x^T/y^T. We can just use SpMV
+// to calculate y^T(:, i) := A^T * x^T(:, i).
+// Input parameters:
+//   m, n, k  : x is m-by-k matrix, A is k-by-n sparse matrix
+//   A_valbuf : Buffer for storing nonzeros of A^T
+//   A_idxbuf : Buffer for storing CSR row_ptr and col_idx arrays of A^T. 
+//              A_idxbuf->data[0 : n] stores row_ptr, A_idxbuf->data[n+1 : end]
+//              stores col_idx.
+//   x, ldx   : m-by-k row-major dense matrix, leading dimension ldx
+//   ldy      : Leading dimension of y
+// Output parameter:
+//   y : m-by-n row-major dense matrix, leading dimension ldy
+void H2E_calc_sparse_mm_trans(
+    const int m, const int n, const int k,
+    H2E_dense_mat_p A_valbuf, H2E_int_vec_p A_idxbuf,
+    DTYPE *x, const int ldx, DTYPE *y, const int ldy
+);
+
+// Convert an integer COO matrix to a CSR matrix 
+// Input parameters:
+//   nrow          : Number of rows
+//   nnz           : Number of nonzeros in the matrix
+//   row, col, val : Size nnz, COO matrix
+// Output parameters:
+//   row_ptr, col_idx, val_ : Size nrow+1, nnz, nnz, CSR matrix
+void H2E_int_COO_to_CSR(
+    const int nrow, const int nnz, const int *row, const int *col, 
+    const int *val, int *row_ptr, int *col_idx, int *val_
+);
+
+// Get the value of integer CSR matrix element A(row, col)
+// Input parameters:
+//   row_ptr, col_idx, val : CSR matrix array triple
+//   row, col              : Target position
+// Output parameter:
+//   <return> : A(row, col) if exists, 0 if not
+int H2E_get_int_CSR_elem(
+    const int *row_ptr, const int *col_idx, const int *val,
+    const int row, const int col
+);
+
+// Partition work units into multiple blocks s.t. each block has 
+// approximately the same amount of work
+// Input parameters:
+//   n_work     : Number of work units
+//   work_sizes : Size n_work, sizes of work units
+//   total_size : Sum of work_sizes
+//   n_block    : Number of blocks to be partitioned, the final result
+//                may have fewer blocks
+// Output parameter:
+//   blk_displs : Indices of each block's first work unit. The actual 
+//                number of work units == blk_displs->length-1 because 
+//                blk_displs->data[0] == 0 and 
+//                blk_displs->data[blk_displs->length-1] == total_size. 
+void H2E_partition_workload(
+    const int n_work,  const size_t *work_sizes, const size_t total_size, 
+    const int n_block, H2E_int_vec_p blk_displs
+);
 
 #ifdef __cplusplus
 }

--- a/src/H2E_ID_compress.c
+++ b/src/H2E_ID_compress.c
@@ -1,0 +1,576 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <math.h>
+#include <float.h>
+
+#include "H2ERI_config.h"
+#include "H2ERI_aux_structs.h"
+#include "H2ERI_utils.h"
+#include "utils.h"
+
+static inline void swap_int(int *x, int *y, int len)
+{
+    int tmp;
+    for (int i = 0; i < len; i++)
+    {
+        tmp  = x[i];
+        x[i] = y[i];
+        y[i] = tmp;
+    }
+}
+
+static inline void swap_DTYPE(DTYPE *x, DTYPE *y, int len)
+{
+    DTYPE tmp;
+    for (int i = 0; i < len; i++)
+    {
+        tmp  = x[i];
+        x[i] = y[i];
+        y[i] = tmp;
+    }
+}
+
+// Partial pivoting QR decomposition, simplified output version
+// The partial pivoting QR decomposition is of form:
+//     A * P = Q * [R11, R12; 0, R22]
+// where R11 is an upper-triangular matrix, R12 and R22 are dense matrices,
+// P is a permutation matrix. 
+// Input parameters:
+//   A        : Target matrix, stored in column major
+//   tol_rank : QR stopping parameter, maximum column rank, 
+//   tol_norm : QR stopping parameter, maximum column 2-norm
+//   rel_norm : If tol_norm is relative to the largest column 2-norm in A
+//   n_thread : Number of threads used in this function
+//   QR_buff  : Size A->ncol, working buffer for partial pivoting QR
+// Output parameters:
+//   A : Matrix R: [R11, R12; 0, R22]
+//   p : Matrix A column permutation array, A(:, p) = A * P
+//   r : Dimension of upper-triangular matrix R11
+void H2E_partial_pivot_QR(
+    H2E_dense_mat_p A, const int tol_rank, const DTYPE tol_norm, 
+    const int rel_norm, int *p, int *r, const int n_thread, DTYPE *QR_buff
+)
+{
+    DTYPE *R = A->data;
+    int nrow = A->nrow;
+    int ncol = A->ncol;
+    int ldR  = A->ld;
+    int max_iter = MIN(nrow, ncol);
+    
+    BLAS_SET_NUM_THREADS(n_thread);
+    
+    DTYPE *col_norm = QR_buff;
+
+    DTYPE eps_t, fast_norm_threshold_t;
+    if (sizeof(DTYPE) == 8)
+    {
+        eps_t = 1e-15;
+        fast_norm_threshold_t = 1e-10;
+    } else {
+        eps_t = 1e-6;
+        fast_norm_threshold_t = 1e-5;
+    }
+    
+    // Find a column with largest 2-norm
+    #pragma omp parallel for if (n_thread > 1) \
+    num_threads(n_thread) schedule(static)
+    for (int j = 0; j < ncol; j++)
+    {
+        p[j] = j;
+        col_norm[j] = CBLAS_NRM2(nrow, R + j * ldR, 1);
+    }
+    DTYPE norm_p = 0.0;
+    int pivot = 0;
+    for (int j = 0; j < ncol; j++)
+    {
+        if (col_norm[j] > norm_p)
+        {
+            norm_p = col_norm[j];
+            pivot = j;
+        }
+    }
+    
+    // Scale the stopping norm
+    int stop_rank = MIN(max_iter, tol_rank);
+    DTYPE norm_eps = DSQRT((DTYPE) nrow) * eps_t;
+    DTYPE stop_norm = MAX(norm_eps, tol_norm);
+    if (rel_norm) stop_norm *= norm_p;
+    
+    int rank = -1;
+    // Main iteration of Household QR
+    for (int i = 0; i < max_iter; i++)
+    {   
+        // 1. Check the stop criteria
+        if ((norm_p < stop_norm) || (i >= stop_rank))
+        {
+            rank = i;
+            break;
+        }
+        
+        // 2. Swap the column
+        if (i != pivot)
+        {
+            swap_int(p + i, p + pivot, 1);
+            swap_DTYPE(col_norm + i, col_norm + pivot, 1);
+            swap_DTYPE(R + i * ldR, R + pivot * ldR, nrow);
+        }
+        
+        // 3. Calculate Householder vector
+        int h_len    = nrow - i;
+        int h_len_m1 = h_len - 1;
+        DTYPE *h_vec = R + i * ldR + i;
+        DTYPE sign   = (h_vec[0] > 0.0) ? 1.0 : -1.0;
+        DTYPE h_norm = CBLAS_NRM2(h_len, h_vec, 1);
+        h_vec[0] = h_vec[0] + sign * h_norm;
+        DTYPE inv_h_norm = 1.0 / CBLAS_NRM2(h_len, h_vec, 1);
+        #pragma omp simd
+        for (int j = 0; j < h_len; j++) h_vec[j] *= inv_h_norm;
+        
+        // 4. & 5. Householder update & column norm update
+        DTYPE *R_block = R + (i + 1) * ldR + i;
+        int R_block_nrow = h_len;
+        int R_block_ncol = ncol - i - 1;
+        #pragma omp parallel for if (n_thread > 1) \
+        num_threads(n_thread) schedule(guided)
+        for (int j = 0; j < R_block_ncol; j++)
+        {
+            int ji1 = j + i + 1;
+            
+            DTYPE *R_block_j = R_block + j * ldR;
+            DTYPE h_Rj = 2.0 * CBLAS_DOT(R_block_nrow, h_vec, 1, R_block_j, 1);
+            
+            // 4. Orthogonalize columns right to the i-th column
+            #pragma omp simd
+            for (int k = 0; k < R_block_nrow; k++)
+                R_block_j[k] -= h_Rj * h_vec[k];
+            
+            // 5. Update i-th column's 2-norm
+            if (col_norm[ji1] < stop_norm)
+            {
+                col_norm[ji1] = 0.0;
+                continue;
+            }
+            DTYPE tmp = R_block_j[0] * R_block_j[0];
+            tmp = col_norm[ji1] * col_norm[ji1] - tmp;
+            if (tmp <= fast_norm_threshold_t)
+            {
+                col_norm[ji1] = CBLAS_NRM2(h_len_m1, R_block_j + 1, 1);
+            } else {
+                // Fast update 2-norm when the new column norm is not so small
+                col_norm[ji1] = DSQRT(tmp);
+            }
+        }
+        
+        // We don't need h_vec anymore, can overwrite the i-th column of R
+        h_vec[0] = -sign * h_norm;
+        memset(h_vec + 1, 0, sizeof(DTYPE) * (h_len - 1));
+        // Find next pivot 
+        pivot  = i + 1;
+        norm_p = 0.0;
+        for (int j = i + 1; j < ncol; j++)
+        {
+            if (col_norm[j] > norm_p)
+            {
+                norm_p = col_norm[j];
+                pivot  = j;
+            }
+        }
+    }
+    if (rank == -1) rank = max_iter;
+    
+    *r = rank;
+}
+
+// H2E_partial_pivot_QR_kdim operated on column blocks for tensor kernel matrix.
+// Each column block has kdim columns. In each step, we swap kdim columns 
+// and do kdim Householder orthogonalization.
+// Size of QR_buff: (2*kdim+2)*A->nrow + (kdim+1)*A->ncol
+// BLAS-3 approach, ref: https://doi.org/10.1145/1513895.1513904
+void H2E_partial_pivot_QR_kdim(
+    H2E_dense_mat_p A, const int kdim, const int tol_rank, const DTYPE tol_norm, 
+    const int rel_norm, int *p, int *r, const int n_thread, DTYPE *QR_buff
+)
+{
+    DTYPE *R = A->data;
+    int nrow = A->nrow;
+    int ncol = A->ncol;
+    int nblk = ncol / kdim;
+    int ldR  = A->ld;
+    int max_iter = MIN(nrow, ncol) / kdim;
+    
+    BLAS_SET_NUM_THREADS(n_thread);
+
+    DTYPE eps_t, fast_norm_threshold_t;
+    if (sizeof(DTYPE) == 8)
+    {
+        eps_t = 1e-15;
+        fast_norm_threshold_t = 1e-10;
+    } else {
+        eps_t = 1e-6;
+        fast_norm_threshold_t = 1e-5;
+    }
+    
+    for (int j = 0; j < ncol; j++) p[j] = j;
+    
+    // Partition the work buffer 
+    DTYPE *blk_norm = QR_buff;
+    DTYPE *Vblk = blk_norm + ncol;
+    DTYPE *Wblk = Vblk + kdim * nrow;
+    DTYPE *VV   = Wblk + kdim * nrow;
+    DTYPE *WVV  = VV   + nrow;
+    DTYPE *WR   = WVV  + nrow;
+    
+    // Find a column with largest 2-norm as a scaling factor
+    #pragma omp parallel for if(n_thread > 1) \
+    num_threads(n_thread) schedule(static)
+    for (int j = 0; j < ncol; j++)
+        blk_norm[j] = CBLAS_NRM2(nrow, R + j * ldR, 1);
+    
+    // Find a column block with largest 2-norm as the first pivot
+    DTYPE norm_p = 0.0;
+    int pivot = 0;
+    for (int j = 0; j < nblk; j++)
+    {
+        DTYPE tmp = 0.0;
+        for (int k = 0; k < kdim; k++) 
+        {
+            int idx = kdim * j + k;
+            tmp += blk_norm[idx] * blk_norm[idx]; 
+        }
+        blk_norm[j] = DSQRT(tmp);
+        if (blk_norm[j] > norm_p)
+        {
+            norm_p = blk_norm[j];
+            pivot  = j;
+        }
+    }
+    
+    // Scale the stopping norm
+    int stop_rank   = MIN(max_iter, tol_rank/kdim);
+    DTYPE norm_eps  = DSQRT((DTYPE) nrow) * eps_t;
+    DTYPE stop_norm = MAX(norm_eps, tol_norm);
+    if (rel_norm) stop_norm *= norm_p;
+    
+    // Main iteration of Household QR
+    int rank = -1;
+    for (int i = 0; i < max_iter; i++)
+    {   
+        // 1. Check the stop criteria
+        if ((norm_p < stop_norm) || (i >= stop_rank))
+        {
+            rank = i * kdim;
+            break;
+        }
+        
+        // 2. Swap the column
+        if (i != pivot)
+        {
+            swap_int(p + i * kdim, p + pivot * kdim, kdim);
+            swap_DTYPE(blk_norm + i, blk_norm + pivot, 1);
+            DTYPE *R_i = R + i * kdim * ldR;
+            DTYPE *R_pivot = R + pivot * kdim * ldR;
+            swap_DTYPE(R_i, R_pivot, ldR * kdim);
+        }
+        
+        int VWblk_nrow = nrow - i * kdim;
+        
+        // 3. Do kdim times of consecutive Householder orthogonalize on the current column block
+        for (int ii = i * kdim; ii < i * kdim + kdim; ii++)
+        {
+            // 3.1 Calculate Householder vector
+            int h_len    = nrow - ii;
+            DTYPE *h_vec = R + ii * ldR + ii;
+            DTYPE sign   = (h_vec[0] > 0.0) ? 1.0 : -1.0;
+            DTYPE h_norm = CBLAS_NRM2(h_len, h_vec, 1);
+            h_vec[0] = h_vec[0] + sign * h_norm;
+            DTYPE inv_h_norm = 1.0 / CBLAS_NRM2(h_len, h_vec, 1);
+            #pragma omp simd
+            for (int j = 0; j < h_len; j++) h_vec[j] *= inv_h_norm;
+            
+            // 3.2 Householder update current column block
+            int blk_i = ii - i * kdim;
+            DTYPE *R_block = R + (ii + 1) * ldR + ii;
+            int R_block_nrow = h_len;
+            //int R_block_ncol = ncol - ii - 1;
+            for (int j = 0; j < kdim - blk_i - 1; j++)
+            {
+                //int ji1 = j + ii + 1;
+                
+                DTYPE *R_block_j = R_block + j * ldR;
+                DTYPE h_Rj = 2.0 * CBLAS_DOT(R_block_nrow, h_vec, 1, R_block_j, 1);
+                
+                // Orthogonalize columns right to the ii-th column
+                #pragma omp simd
+                for (int k = 0; k < R_block_nrow; k++)
+                    R_block_j[k] -= h_Rj * h_vec[k];
+            }
+            
+            // Save the Householder vector for block update
+            for (int j = 0; j < blk_i; j++) Vblk[blk_i * VWblk_nrow + j] = 0.0;
+            memcpy(Vblk + blk_i * VWblk_nrow + blk_i, h_vec, sizeof(DTYPE) * h_len);
+            
+            // We don't need h_vec anymore, can overwrite the i-th column of R
+            h_vec[0] = -sign * h_norm;
+            memset(h_vec + 1, 0, sizeof(DTYPE) * (h_len - 1));
+        }
+        
+        // 4. Construct W, use V & W for block Householder update 
+        #pragma omp simd
+        for (int j = 0; j < VWblk_nrow; j++) Wblk[j] = -2.0 * Vblk[j];
+        for (int ii = 1; ii < kdim; ii++)
+        {
+            DTYPE *Vii = Vblk + ii * VWblk_nrow;
+            DTYPE *Wii = Wblk + ii * VWblk_nrow;
+            CBLAS_GEMV(
+                CblasColMajor, CblasTrans, VWblk_nrow, ii, 
+                1.0, Vblk, VWblk_nrow, Vii, 1, 0.0, VV, 1
+            );
+            CBLAS_GEMV(
+                CblasColMajor, CblasNoTrans, VWblk_nrow, ii,
+                1.0, Wblk, VWblk_nrow, VV, 1, 0.0, WVV, 1    
+            );
+            #pragma omp simd
+            for (int j = 0; j < VWblk_nrow; j++)
+                Wii[j] = -2.0 * (Vii[j] + WVV[j]);
+        }
+        int R_blk_scol = i * kdim + kdim;
+        int R_blk_ncol = ncol - R_blk_scol;
+        DTYPE *R_blk = R + R_blk_scol * ldR + (i * kdim);
+        int R_col_blk_128KB = 128 * 1024;
+        R_col_blk_128KB /= (int) sizeof(DTYPE);
+        R_col_blk_128KB /= (VWblk_nrow * kdim * 3);
+        if (R_col_blk_128KB < 2) R_col_blk_128KB = 8;
+        for (int R_col_offset = 0; R_col_offset < R_blk_ncol; R_col_offset += R_col_blk_128KB)
+        {
+            int R_col_blksize = R_col_blk_128KB;
+            if (R_col_blksize + R_col_offset > R_blk_ncol) R_col_blksize = R_blk_ncol - R_col_offset;
+            CBLAS_GEMM(
+                CblasColMajor, CblasTrans, CblasNoTrans,
+                kdim, R_col_blksize, VWblk_nrow, 
+                1.0, Wblk, VWblk_nrow, R_blk + ldR * R_col_offset, ldR, 
+                0.0, WR, kdim
+            );
+            CBLAS_GEMM(
+                CblasColMajor, CblasNoTrans, CblasNoTrans, 
+                VWblk_nrow, R_col_blksize, kdim, 
+                1.0, Vblk, VWblk_nrow, WR, kdim, 
+                1.0, R_blk + ldR * R_col_offset, ldR
+            );
+        }
+        
+        // 5. Update i-th column's 2-norm
+        #pragma omp parallel for if(n_thread > 1) \
+        num_threads(n_thread) schedule(guided)
+        for (int j = i + 1; j < nblk; j++)
+        {
+            if (blk_norm[j] < stop_norm)
+            {
+                blk_norm[j] = 0.0;
+                continue;
+            }
+            // R(i * kdim, j * kdim + k)
+            DTYPE *R_block = R + i * kdim + j * kdim * ldR;
+            DTYPE tmp = blk_norm[j] * blk_norm[j];
+            for (int k0 = 0; k0 < kdim; k0++)
+            {
+                for (int k1 = 0; k1 < kdim; k1++)
+                {
+                    int idx = k0 * ldR + k1;
+                    tmp -= R_block[idx] * R_block[idx];
+                }
+            }
+            
+            if (tmp <= fast_norm_threshold_t)
+            {
+                const int nrm_len = nrow - (i + 1) * kdim;
+                tmp = 0.0;
+                for (int k = 0; k < kdim; k++)
+                {
+                    // R((i + 1) * kdim, j * kdim + k)
+                    DTYPE *R_block_k = R + (j*kdim+k) * ldR + (i+1) * kdim;
+                    DTYPE tmp1 = CBLAS_NRM2(nrm_len, R_block_k, 1);
+                    tmp += tmp1 * tmp1;
+                }
+                blk_norm[j] = DSQRT(tmp);
+            } else {
+                // Fast update 2-norm when the new column norm is not so small
+                blk_norm[j] = DSQRT(tmp);
+            }
+        }
+        
+        // 6. Find next pivot 
+        pivot  = i + 1;
+        norm_p = 0.0;
+        for (int j = i + 1; j < nblk; j++)
+        {
+            if (blk_norm[j] > norm_p)
+            {
+                norm_p = blk_norm[j];
+                pivot  = j;
+            }
+        }
+    }
+    if (rank == -1) rank = max_iter * kdim;
+    
+    *r = rank;
+}
+
+
+// Partial pivoting QR for ID
+// Input parameters:
+//   A          : Target matrix, stored in column major
+//   stop_type  : Partial QR stop criteria: QR_RANK, QR_REL_NRM, or QR_ABS_NRM
+//   stop_param : Pointer to partial QR stop parameter
+//   n_thread   : Number of threads used in this function
+//   QR_buff    : Working buffer for partial pivoting QR. If kdim == 1, size A->ncol.
+//                If kdim > 1, size (2*kdim+2)*A->nrow + (kdim+1)*A->ncol.
+//   kdim       : Dimension of tensor kernel's return (column block size)
+// Output parameters:
+//   A : Matrix R: [R11, R12]
+//   p : Matrix A column permutation array, A(:, p) = A * P
+void H2E_ID_QR(
+    H2E_dense_mat_p A, const int stop_type, void *stop_param, int *p, 
+    const int n_thread, DTYPE *QR_buff, const int kdim
+)
+{
+    // Parse partial QR stop criteria and perform partial QR
+    int r, tol_rank = MIN(A->nrow, A->ncol), rel_norm = 1;
+    DTYPE tol_norm = 1e-15;
+    if (stop_type == QR_RANK)
+    {
+        int *param = (int*) stop_param;
+        tol_rank = param[0];
+        tol_norm = 1e-15;
+        rel_norm = 1;
+    }
+    if (stop_type == QR_REL_NRM)
+    {
+        DTYPE *param = (DTYPE*) stop_param;
+        tol_rank = MIN(A->nrow, A->ncol);
+        tol_norm = param[0] * DSQRT((DTYPE) kdim);
+        rel_norm = 1;
+    }
+    if (stop_type == QR_ABS_NRM)
+    {
+        DTYPE *param = (DTYPE*) stop_param;
+        tol_rank = MIN(A->nrow, A->ncol);
+        tol_norm = param[0];
+        rel_norm = 0;
+    }
+    // Use H2E_partial_pivot_QR_kdim() for kdim == 1 also works,
+    // but the performance is worse than H2E_partial_pivot_QR()
+    if (kdim == 1)
+    {
+        H2E_partial_pivot_QR(
+            A, tol_rank, tol_norm, rel_norm, 
+            p, &r, n_thread, QR_buff
+        );
+    } else {
+        H2E_partial_pivot_QR_kdim(
+            A, kdim, tol_rank, tol_norm, rel_norm, 
+            p, &r, n_thread, QR_buff
+        );
+    }
+    
+    // Special case: each column's 2-norm is smaller than the threshold
+    if (r == 0)
+    {
+        for (int i = 0; i < A->ncol; i++) p[i] = i;
+        A->nrow = 0;
+        return;
+    }
+    
+    // Truncate R to be [R11, R12] and return
+    A->nrow = r;
+}
+
+// Interpolative Decomposition (ID) using partial QR over rows of a target 
+// matrix. Partial pivoting QR may need to be upgraded to SRRQR later. 
+void H2E_ID_compress(
+    H2E_dense_mat_p A, const int stop_type, void *stop_param, H2E_dense_mat_p *U_, 
+    H2E_int_vec_p J, const int n_thread, DTYPE *QR_buff, int *ID_buff, const int kdim
+)
+{
+    // 1. Partial pivoting QR for A^T
+    // Note: A is stored in row major style but H2E_ID_QR needs A stored in column
+    // major style. We manipulate the size information of A to save some time
+    const int nrow = A->nrow;
+    const int ncol = A->ncol;
+    A->nrow = ncol;
+    A->ncol = nrow;
+    H2E_int_vec_set_capacity(J, nrow);
+    H2E_ID_QR(A, stop_type, stop_param, J->data, n_thread, QR_buff, kdim);
+    H2E_dense_mat_p R = A; // Note: the output R stored in A is still stored in column major style
+    int r = A->nrow;  // Obtained rank
+    J->length = r;
+    
+    // 2. Set permutation indices p0, sort the index subset J[0:r-1]
+    int *p0 = ID_buff + 0 * nrow;
+    int *p1 = ID_buff + 1 * nrow;
+    int *i0 = ID_buff + 2 * nrow;
+    int *i1 = ID_buff + 3 * nrow;
+    for (int i = 0; i < nrow; i++) 
+    {
+        p0[J->data[i]] = i;
+        i0[i] = i;
+    }
+    H2E_qsort_int_kv_ascend(J->data, i0, 0, r - 1);
+    for (int i = 0; i < nrow; i++) i1[i0[i]] = i;
+    for (int i = 0; i < nrow; i++) p1[i] = i1[p0[i]];
+    
+    // 3. Form the output U
+    H2E_dense_mat_p U;
+    if (r == 0)
+    {
+        // Special case: rank = 0, set U and J as empty
+        H2E_dense_mat_init(&U, 0, 0);
+        U->nrow = nrow;
+        U->ncol = 0;
+        U->ld   = 0;
+        U->data = NULL;
+    } else {
+        if (U_ != NULL)
+        {
+            // (1) Before permutation, the upper part of U is a diagonal
+            H2E_dense_mat_init(&U, nrow, r);
+            for (int i = 0; i < r; i++)
+            {
+                memset(U->data + i * r, 0, sizeof(DTYPE) * r);
+                U->data[i * r + i] = 1.0;
+            }
+            DTYPE *R11 = R->data;
+            DTYPE *R12 = R->data + r * R->ld;
+            int nrow_R12 = r;
+            int ncol_R12 = nrow - r;
+            // (2) Solve E = inv(R11) * R12, stored in R12 in column major style
+            //     --> equals to what we need: E^T stored in row major style
+            BLAS_SET_NUM_THREADS(n_thread);
+            CBLAS_TRSM(
+                CblasColMajor, CblasLeft, CblasUpper, CblasNoTrans, CblasNonUnit,
+                nrow_R12, ncol_R12, 1.0, R11, R->ld, R12, R->ld
+            );
+            // (3) Reorder E^T's columns according to the sorted J
+            DTYPE *UL = U->data + r * r;
+            for (int icol = 0; icol < r; icol++)
+            {
+                DTYPE *R12_icol = R12 + i0[icol];
+                DTYPE *UL_icol = UL + icol;
+                for (int irow = 0; irow < ncol_R12; irow++)
+                    UL_icol[irow * r] = R12_icol[irow * R->ld];
+            }
+            // (4) Permute U's rows 
+            H2E_dense_mat_permute_rows(U, p1);
+        }
+    }
+    if (kdim > 1)
+    {
+        J->data[0] /= kdim;
+        for (int i = 1; i < J->length / kdim; i++)
+            J->data[i] = J->data[i * kdim] / kdim;
+        J->length /= kdim;
+    }
+    
+    if (U_ != NULL) *U_ = U;
+}

--- a/src/common.make
+++ b/src/common.make
@@ -4,13 +4,12 @@ LIB_SO  = libH2PERI.so
 C_SRCS  = $(wildcard *.c)
 C_OBJS  = $(C_SRCS:.c=.c.o)
 
-SIMINT_INSTALL_DIR   = /home/mkurisu/Workspace/simint/build-avx/install
-H2PACK_INSTALL_DIR   = /home/mkurisu/Workspace/H2Pack
-OPENBLAS_INSTALL_DIR = /home/mkurisu/Workspace/OpenBLAS-git/install
+SIMINT_INSTALL_DIR   = /home/keqing/workspace/simint-13May2021/build-icc20-avx/install
+OPENBLAS_INSTALL_DIR = /home/keqing/workspace/OpenBLAS-git/install
 
 DEFS    = 
-INCS    = -I$(SIMINT_INSTALL_DIR)/include -I$(H2PACK_INSTALL_DIR)/include
-CFLAGS  = $(INCS) -Wall -g -std=gnu11 -O3 -fPIC $(DEFS)
+INCS    = -I$(SIMINT_INSTALL_DIR)/include
+CFLAGS  = $(INCS) -Wall -g -std=gnu11 -O2 -fPIC $(DEFS)
 
 ifeq ($(shell $(CC) --version 2>&1 | grep -c "icc"), 1)
 AR      = xiar rcs

--- a/src/linalg_lib_wrapper.h
+++ b/src/linalg_lib_wrapper.h
@@ -1,0 +1,22 @@
+#ifndef __LINALG_LIB_WRAPPER_H__
+#define __LINALG_LIB_WRAPPER_H__
+
+// Wrapper for linear algebra library (BLAS, LAPACK)
+
+#if !defined(USE_MKL) && !defined(USE_OPENBLAS)
+#define USE_OPENBLAS
+#endif
+
+#ifdef USE_MKL
+#include <mkl.h>
+#define BLAS_SET_NUM_THREADS mkl_set_num_threads
+#endif
+
+#ifdef USE_OPENBLAS
+#include <cblas.h>
+#include <lapacke.h>
+#define BLAS_SET_NUM_THREADS openblas_set_num_threads
+#endif
+
+#endif
+

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,224 @@
+// @brief    : Implementations of some helper functions I use here and there
+// @author   : Hua Huang <huangh223@gatech.edu>
+// @modified : 2020-12-03
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <complex.h>
+#include <sys/time.h>
+#include <math.h>
+
+#include "utils.h"
+
+// Get wall-clock time in seconds
+double get_wtime_sec()
+{
+    double sec;
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    sec = tv.tv_sec + (double) tv.tv_usec / 1000000.0;
+    return sec;
+}
+
+// Partition an array into multiple same-size blocks and return the 
+// start position of a given block
+void calc_block_spos_len(
+    const int len, const int nblk, const int iblk,
+    int *blk_spos, int *blk_len
+)
+{
+	if (iblk < 0 || iblk > nblk)
+    {
+        *blk_spos = -1;
+        *blk_len  = 0;
+        return;
+    }
+	int rem = len % nblk;
+	int bs0 = len / nblk;
+	int bs1 = bs0 + 1;
+	if (iblk < rem) 
+    {
+        *blk_spos = bs1 * iblk;
+        *blk_len  = bs1;
+    } else {
+        *blk_spos = bs0 * iblk + rem;
+        *blk_len  = bs0;
+    }
+}
+
+// Allocate a piece of aligned memory 
+void *malloc_aligned(size_t size, size_t alignment)
+{
+    void *ptr = NULL;
+    posix_memalign(&ptr, alignment, size);
+    return ptr;
+}
+
+// Free a piece of aligned memory allocated by malloc_aligned()
+void free_aligned(void *mem)
+{
+    free(mem);
+}
+
+// Calculate the 2-norm of a vector
+// Warning: this is a naive implementation, not numerically stable
+double calc_2norm(const int len, const double *x)
+{
+    double res = 0.0;
+    for (int i = 0; i < len; i++) res += x[i] * x[i];
+    return sqrt(res);
+}
+
+// Calculate the 2-norm of the difference between two vectors 
+// and the 2-norm of the reference vector 
+void calc_err_2norm(
+    const int len, const double *x0, const double *x1, 
+    double *x0_2norm_, double *err_2norm_
+)
+{
+    double x0_2norm = 0.0, err_2norm = 0.0, diff;
+    for (int i = 0; i < len; i++)
+    {
+        diff = x0[i] - x1[i];
+        x0_2norm  += x0[i] * x0[i];
+        err_2norm += diff  * diff;
+    }
+    *x0_2norm_  = sqrt(x0_2norm);
+    *err_2norm_ = sqrt(err_2norm);
+}
+
+// Copy a row-major matrix block to another row-major matrix
+void copy_matrix_block(
+    const size_t dt_size, const int nrow, const int ncol, 
+    const void *src, const int lds, void *dst, const int ldd
+)
+{
+    const char *src_ = (char*) src;
+    char *dst_ = (char*) dst;
+    const size_t lds_ = dt_size * (size_t) lds;
+    const size_t ldd_ = dt_size * (size_t) ldd;
+    const size_t row_msize = dt_size * (size_t) ncol;
+    for (int irow = 0; irow < nrow; irow++)
+    {
+        size_t src_offset = (size_t) irow * lds_;
+        size_t dst_offset = (size_t) irow * ldd_;
+        memcpy(dst_ + dst_offset, src_ + src_offset, row_msize);
+    }
+}
+
+// Gather elements from a vector to another vector
+void gather_vector_elements(const size_t dt_size, const int nelem, const int *idx, const void *src, void *dst)
+{
+    if (dt_size == 4)
+    {
+        const float *src_ = (float*) src;
+        float *dst_ = (float*) dst;
+        #if defined(_OPENMP)
+        #pragma omp simd
+        #endif
+        for (int i = 0; i < nelem; i++) dst_[i] = src_[idx[i]];
+    }
+    if (dt_size == 8)
+    {
+        const double *src_ = (double*) src;
+        double *dst_ = (double*) dst;
+        #if defined(_OPENMP)
+        #pragma omp simd
+        #endif
+        for (int i = 0; i < nelem; i++) dst_[i] = src_[idx[i]];
+    }
+    if (dt_size == 16)
+    {
+        const double _Complex *src_ = (double _Complex*) src;
+        double _Complex *dst_ = (double _Complex*) dst;
+        #if defined(_OPENMP)
+        #pragma omp simd
+        #endif
+        for (int i = 0; i < nelem; i++) dst_[i] = src_[idx[i]];
+    }
+}
+
+// Gather rows from a matrix to another matrix
+void gather_matrix_rows(
+    const size_t dt_size, const int nrow, const int ncol, const int *idx, 
+    const void *src, const int lds, void *dst, const int ldd
+)
+{
+    const char *src_ = (char*) src;
+    char *dst_ = (char*) dst;
+    const size_t lds_ = dt_size * (size_t) lds;
+    const size_t ldd_ = dt_size * (size_t) ldd;
+    const size_t row_msize = dt_size * (size_t) ncol;
+    #if defined(_OPENMP)
+    #pragma omp parallel for schedule(static)
+    #endif
+    for (int irow = 0; irow < nrow; irow++)
+    {
+        size_t src_offset = (size_t) idx[irow] * lds_;
+        size_t dst_offset = (size_t) irow * ldd_;
+        memcpy(dst_ + dst_offset, src_ + src_offset, row_msize);
+    }
+}
+
+// Gather columns from a matrix to another matrix
+void gather_matrix_cols(
+    const size_t dt_size, const int nrow, const int ncol, const int *idx, 
+    const void *src, const int lds, void *dst, const int ldd
+)
+{
+    const char *src_ = (char*) src;
+    char *dst_ = (char*) dst;
+    const size_t lds_ = dt_size * (size_t) lds;
+    const size_t ldd_ = dt_size * (size_t) ldd;
+    #if defined(_OPENMP)
+    #pragma omp parallel for schedule(static)
+    #endif
+    for (int irow = 0; irow < nrow; irow++)
+    {
+        size_t src_offset = (size_t) irow * lds_;
+        size_t dst_offset = (size_t) irow * ldd_;
+        gather_vector_elements(dt_size, ncol, idx, src_ + src_offset, dst_ + dst_offset);
+    }
+}
+
+// Print a row-major int matrix block to standard output
+void print_int_mat_blk(
+    const int *mat, const int ldm, const int nrow, const int ncol, 
+    const char *fmt, const char *mat_name
+)
+{
+    printf("%s:\n", mat_name);
+    for (int i = 0; i < nrow; i++)
+    {
+        const int *mat_i = mat + i * ldm;
+        for (int j = 0; j < ncol; j++)
+        {
+            printf(fmt, mat_i[j]);
+            printf("  ");
+        }
+        printf("\n");
+    }
+    printf("\n");
+}
+
+// Print a row-major double matrix block to standard output
+void print_dbl_mat_blk(
+    const double *mat, const int ldm, const int nrow, const int ncol, 
+    const char *fmt, const char *mat_name
+)
+{
+    printf("%s:\n", mat_name);
+    for (int i = 0; i < nrow; i++)
+    {
+        const double *mat_i = mat + i * ldm;
+        for (int j = 0; j < ncol; j++)
+        {
+            printf(fmt, mat_i[j]);
+            printf("  ");
+        }
+        printf("\n");
+    }
+    printf("\n");
+}
+

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,221 @@
+// @brief    : Implementations of some helper functions I use here and there
+// @author   : Hua Huang <huangh223@gatech.edu>
+// @modified : 2020-08-30
+
+#ifndef __HUANGH223_UTILS_H__
+#define __HUANGH223_UTILS_H__
+
+#ifdef __cplusplus
+#include <cassert>
+#else
+#include <assert.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define INT_MSIZE sizeof(int)
+#define DBL_MSIZE sizeof(double)
+
+#define MIN(a, b)  ((a) < (b) ? (a) : (b))
+#define MAX(a, b)  ((a) > (b) ? (a) : (b))
+
+#define INFO_PRINTF(fmt, ...)                       \
+    do                                              \
+    {                                               \
+        fprintf(stdout, "[INFO] %s, %d: " fmt,      \
+                __FILE__, __LINE__, ##__VA_ARGS__); \
+        fflush(stdout);                             \
+    } while (0)
+
+#define DEBUG_PRINTF(fmt, ...)                      \
+    do                                              \
+    {                                               \
+        fprintf(stderr, "[DEBUG] %s, %d: " fmt,     \
+                __FILE__, __LINE__, ##__VA_ARGS__); \
+        fflush(stderr);                             \
+    } while (0)
+
+#define WARNING_PRINTF(fmt, ...)                    \
+    do                                              \
+    {                                               \
+        fprintf(stderr, "[WARNING] %s, %d: " fmt,   \
+                __FILE__, __LINE__, ##__VA_ARGS__); \
+        fflush(stderr);                             \
+    } while (0)
+
+#define ERROR_PRINTF(fmt, ...)                      \
+    do                                              \
+    {                                               \
+        fprintf(stderr, "[ERROR] %s, %d: " fmt,     \
+                __FILE__, __LINE__, ##__VA_ARGS__); \
+        fflush(stderr);                             \
+    } while (0)
+
+#define ASSERT_PRINTF(expr, fmt, ...)                   \
+    do                                                  \
+    {                                                   \
+        if (!(expr))                                    \
+        {                                               \
+            fprintf(stderr, "[FATAL] %s, %d: " fmt,     \
+                    __FILE__, __LINE__, ##__VA_ARGS__); \
+            fflush(stderr);                             \
+            assert(expr);                               \
+        }                                               \
+    } while (0)
+
+
+#define GET_ENV_INT_VAR(var, env_str, var_str, default_val, min_val, max_val) \
+    do                                          \
+    {                                           \
+        char *env_str_p = getenv(env_str);      \
+        if (env_str_p != NULL)                  \
+        {                                       \
+            var = atoi(env_str_p);              \
+            if (var < min_val || var > max_val) var = default_val;  \
+            INFO_PRINTF("Overriding parameter %s: %d (default) --> %d (runtime)\n", var_str, default_val, var); \
+        } else {                                \
+            var = default_val;                  \
+        }                                       \
+    } while (0)
+
+// Get wall-clock time in seconds
+// Output parameter:
+//   <return> : Wall-clock time in second
+double get_wtime_sec();
+
+// Partition an array into multiple same-size blocks and return the 
+// start position of a given block
+// Input parameters:
+//   len  : Length of the array
+//   nblk : Total number of blocks to be partitioned
+//   iblk : Index of the block whose start position we need.
+//          0 <= iblk <= nblk, iblk == 0/nblk return 0/len.
+// Output parameters:
+//   *blk_spos : The start position of the iblk-th block, -1 means invalid parameters
+//   *blk_len  : The length of the iblk-th block
+void calc_block_spos_len(
+    const int len, const int nblk, const int iblk,
+    int *blk_spos, int *blk_len
+);
+
+// Allocate a piece of aligned memory 
+// Input parameters:
+//   size      : Size of the memory to be allocated, in bytes
+//   alignment : Size of the alignment, in bytes, must be a power of 8
+// Output parameter:
+//   <return>  : Pointer to the allocated aligned memory
+void *malloc_aligned(size_t size, size_t alignment);
+
+// Free a piece of aligned memory allocated by malloc_aligned()
+// Input parameter:
+//   mem : Pointer to the memory to be free
+void free_aligned(void *mem);
+
+// Calculate the 2-norm of a vector
+// Warning: this is a naive implementation, not numerically stable
+// Input parameters:
+//   len : Length of the vector
+//   x   : Size >= len, vector
+// Output parameter:
+//   <return> : 2-norm of vector x
+double calc_2norm(const int len, const double *x);
+
+// Calculate the 2-norm of the difference between two vectors 
+// and the 2-norm of the reference vector 
+// Input parameters:
+//   len : Length of the vector
+//   x0  : Size >= len, reference vector
+//   x1  : Size >= len, target vector to be compared 
+// Output parameters:
+//   *x0_2norm_  : 2-norm of vector x0
+//   *err_2norm_ : 2-norm of vector (x0 - x1)
+void calc_err_2norm(
+    const int len, const double *x0, const double *x1, 
+    double *x0_2norm_, double *err_2norm_
+);
+
+// Copy a row-major matrix block to another row-major matrix
+// Input parameters:
+//   dt_size : Size of matrix element data type, in bytes
+//   nrow    : Number of rows to be copied
+//   ncol    : Number of columns to be copied
+//   src     : Size >= lds * nrow, source matrix
+//   lds     : Leading dimension of src, >= ncol
+//   ldd     : Leading dimension of dst, >= ncol
+// Output parameter:
+//   dst : Size >= ldd * nrow, destination matrix
+void copy_matrix_block(
+    const size_t dt_size, const int nrow, const int ncol,
+    const void *src, const int lds, void *dst, const int ldd
+);
+
+// Gather elements from a vector to another vector
+// Input parameters:
+//   dt_size : Size of vector element data type, in bytes, now support 4, 8, 16
+//   nelem   : Number of elements to gather
+//   idx     : Indices of elements to gather
+//   src     : Size >= max(idx), source vector
+// Output parameter:
+//   dst : Size >= nelem, destination vector, dst[i] = src[idx[i]]
+void gather_vector_elements(const size_t dt_size, const int nelem, const int *idx, const void *src, void *dst);
+
+// Gather rows from a matrix to another matrix
+// Input parameters:
+//   dt_size : Size of matrix element data type, in bytes
+//   nrow    : Number of rows to gather
+//   ncol    : Number of columns the source matrix has
+//   idx     : Indices of rows to gather
+//   src     : Size >= max(idx) * lds, source matrix
+//   lds     : Leading dimension of source matrix, >= ncol
+//   ldd     : Leading dimension of destination matrix, >= ncol
+// Output parameter:
+//   dst : Size >= nrow * ldd, destination matrix
+void gather_matrix_rows(
+    const size_t dt_size, const int nrow, const int ncol, const int *idx, 
+    const void *src, const int lds, void *dst, const int ldd
+);
+
+// Gather columns from a matrix to another matrix
+// Input parameters:
+//   dt_size : Size of matrix element data type, in bytes, now support 4, 8, 16
+//   nrow    : Number of rows the source matrix has
+//   ncol    : Number of columns to gather
+//   idx     : Indices of rows to gather
+//   src     : Size >= nrow * lds, source matrix
+//   lds     : Leading dimension of source matrix, >= max(idx)
+//   ldd     : Leading dimension of destination matrix, >= ncol
+// Output parameter:
+//   dst : Size >= nrow * ldd, destination matrix
+void gather_matrix_cols(
+    const size_t dt_size, const int nrow, const int ncol, const int *idx, 
+    const void *src, const int lds, void *dst, const int ldd
+);
+
+// Print a row-major int matrix block to standard output
+// Input parameters:
+//   mat      : Size >= ldm * nrow, matrix to be printed 
+//   ldm      : Leading dimension of mat, >= ncol
+//   nrow     : Number of rows to be printed
+//   ncol     : Number of columns to be printed
+//   fmt      : Output format string
+//   mat_name : Name of the matrix, to be printed
+void print_int_mat_blk(
+    const int *mat, const int ldm, const int nrow, const int ncol, 
+    const char *fmt, const char *mat_name
+);
+
+// Print a row-major double matrix block to standard output
+// Input / output parameters are the same as copy_int_mat_blk()
+void print_dbl_mat_blk(
+    const double *mat, const int ldm, const int nrow, const int ncol, 
+    const char *fmt, const char *mat_name
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/tests/common.make
+++ b/tests/common.make
@@ -1,15 +1,14 @@
-LIBXC_INSTALL_DIR    = /home/mkurisu/Workspace/libxc/install
+LIBXC_INSTALL_DIR    = /home/keqing/workspace/libxc/install
 H2PERI_INSTALL_DIR   = ..
-SIMINT_INSTALL_DIR   = /home/mkurisu/Workspace/simint/build-avx/install
-YATDFT_INSTALL_DIR   = /home/mkurisu/Workspace/YATDFT
-H2PACK_INSTALL_DIR   = /home/mkurisu/Workspace/H2Pack
-OPENBLAS_INSTALL_DIR = /home/mkurisu/Workspace/OpenBLAS-git/install
+SIMINT_INSTALL_DIR   = /home/keqing/workspace/simint-13May2021/build-icc20-avx/install
+YATDFT_INSTALL_DIR   = /home/keqing/workspace/YATDFT
+OPENBLAS_INSTALL_DIR = /home/keqing/workspace/OpenBLAS-git/install
 
 DEFS    = 
-INCS    = -I$(H2PERI_INSTALL_DIR)/include -I$(H2PACK_INSTALL_DIR)/include -I$(YATDFT_INSTALL_DIR)/include -I$(SIMINT_INSTALL_DIR)/include
+INCS    = -I$(H2PERI_INSTALL_DIR)/include -I$(YATDFT_INSTALL_DIR)/include -I$(SIMINT_INSTALL_DIR)/include
 CFLAGS  = $(INCS) -Wall -g -std=gnu11 -O3 -fPIC $(DEFS)
 LDFLAGS = -g -O3 -fopenmp
-LIBS    = $(H2PERI_INSTALL_DIR)/lib/libH2PERI.a $(H2PACK_INSTALL_DIR)/lib/libH2Pack.a $(YATDFT_INSTALL_DIR)/lib/libYATDFT.a $(SIMINT_INSTALL_DIR)/lib64/libsimint.a 
+LIBS    = $(H2PERI_INSTALL_DIR)/lib/libH2PERI.a $(YATDFT_INSTALL_DIR)/lib/libYATDFT.a $(SIMINT_INSTALL_DIR)/lib64/libsimint.a 
 
 ifeq ($(shell $(CC) --version 2>&1 | grep -c "icc"), 1)
 CFLAGS  += -fopenmp -xHost

--- a/tests/test_J_input_mat.c
+++ b/tests/test_J_input_mat.c
@@ -44,8 +44,8 @@ int main(int argc, char **argv)
     
     // 6. Construct the Coulomb matrix and save it to file
     H2ERI_build_Coulomb(h2eri, D_mat, J_mat);  // Warm up
-    h2eri->h2pack->n_matvec = 0;
-    memset(h2eri->h2pack->timers + 4, 0, sizeof(double) * 5);
+    h2eri->n_matvec = 0;
+    memset(h2eri->timers + 4, 0, sizeof(double) * 5);
     for (int k = 0; k < 10; k++)
         H2ERI_build_Coulomb(h2eri, D_mat, J_mat);
     

--- a/tests/test_perf.c
+++ b/tests/test_perf.c
@@ -56,8 +56,8 @@ int main(int argc, char **argv)
     
     // Test H2ERI_build_Coulomb() performance after warm-up running
     H2ERI_build_Coulomb(h2eri, TinyDFT->D_mat, TinyDFT->J_mat);
-    h2eri->h2pack->n_matvec = 0;
-    memset(h2eri->h2pack->timers + 4, 0, sizeof(double) * 5);
+    h2eri->n_matvec = 0;
+    memset(h2eri->timers + 4, 0, sizeof(double) * 5);
     st = get_wtime_sec();
     int ntest = 10;
     for (int i = 0; i < ntest; i++)


### PR DESCRIPTION
Copy some functions from H2Pack and rename their prefix. 
Makes compiling H2P-ERI easier. 